### PR TITLE
feature/ add ruff formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,9 @@
 fail_fast: false
 repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.8
+    hooks:
+      - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:

--- a/site/mex_invenio/config/settings.py
+++ b/site/mex_invenio/config/settings.py
@@ -12,7 +12,11 @@ from datetime import datetime
 from invenio_app_rdm.config import OAISERVER_METADATA_FORMATS
 from invenio_i18n import lazy_gettext as _
 
-from mex_invenio.custom_fields.custom_fields import RDM_NAMESPACES, RDM_CUSTOM_FIELDS, RDM_CUSTOM_FIELDS_UI
+from mex_invenio.custom_fields.custom_fields import (
+    RDM_NAMESPACES,
+    RDM_CUSTOM_FIELDS,
+    RDM_CUSTOM_FIELDS_UI,
+)
 
 
 def _(x):  # needed to avoid start time failure with lazy strings
@@ -38,42 +42,44 @@ SECRET_KEY = "CHANGE_ME"
 # provided, the allowed hosts variable is set to localhost. In production it
 # should be set to the correct host and it is strongly recommended to only
 # route correct hosts to the application.
-APP_ALLOWED_HOSTS = ['0.0.0.0', 'localhost', '127.0.0.1']
+APP_ALLOWED_HOSTS = ["0.0.0.0", "localhost", "127.0.0.1"]
 
 # Flask-SQLAlchemy
 # ================
 # See https://flask-sqlalchemy.palletsprojects.com/en/2.x/config/
 
 # TODO: Set
-SQLALCHEMY_DATABASE_URI = "postgresql+psycopg2://mex-invenio:mex-invenio@localhost/mex-invenio"
+SQLALCHEMY_DATABASE_URI = (
+    "postgresql+psycopg2://mex-invenio:mex-invenio@localhost/mex-invenio"
+)
 
 # Invenio-App
 # ===========
 # See https://invenio-app.readthedocs.io/en/latest/configuration.html
 
 APP_DEFAULT_SECURE_HEADERS = {
-    'content_security_policy': {
-        'default-src': [
+    "content_security_policy": {
+        "default-src": [
             "'self'",
-            'data:',  # for fonts
+            "data:",  # for fonts
             "'unsafe-inline'",  # for inline scripts and styles
             "blob:",  # for pdf preview
             # Add your own policies here (e.g. analytics)
         ],
     },
-    'content_security_policy_report_only': False,
-    'content_security_policy_report_uri': None,
-    'force_file_save': False,
-    'force_https': True,
-    'force_https_permanent': False,
-    'frame_options': 'sameorigin',
-    'frame_options_allow_from': None,
-    'session_cookie_http_only': True,
-    'session_cookie_secure': True,
-    'strict_transport_security': True,
-    'strict_transport_security_include_subdomains': True,
-    'strict_transport_security_max_age': 31556926,  # One year in seconds
-    'strict_transport_security_preload': False,
+    "content_security_policy_report_only": False,
+    "content_security_policy_report_uri": None,
+    "force_file_save": False,
+    "force_https": True,
+    "force_https_permanent": False,
+    "frame_options": "sameorigin",
+    "frame_options_allow_from": None,
+    "session_cookie_http_only": True,
+    "session_cookie_secure": True,
+    "strict_transport_security": True,
+    "strict_transport_security_include_subdomains": True,
+    "strict_transport_security_max_age": 31556926,  # One year in seconds
+    "strict_transport_security_preload": False,
 }
 
 # Flask-Babel
@@ -82,15 +88,15 @@ APP_DEFAULT_SECURE_HEADERS = {
 
 # Default locale (language)
 # Default time zone
-BABEL_DEFAULT_TIMEZONE = 'Europe/Zurich'
+BABEL_DEFAULT_TIMEZONE = "Europe/Zurich"
 
 # Invenio-I18N
 # ============
 # See https://invenio-i18n.readthedocs.io/en/latest/configuration.html
 
 # Other supported languages (do not include BABEL_DEFAULT_LOCALE in list).
-BABEL_DEFAULT_LOCALE = 'de'
-I18N_LANGUAGES = [('en', _('English'))]
+BABEL_DEFAULT_LOCALE = "de"
+I18N_LANGUAGES = [("en", _("English"))]
 
 # Invenio-Theme
 # =============
@@ -103,15 +109,15 @@ THEME_FRONTPAGE_TITLE = "Metadata Exchange"
 # Intro section
 THEME_SHOW_FRONTPAGE_INTRO_SECTION = False
 # Header logo
-ORGANISATION_LOGO = 'images/RKI-logo.svg'
-THEME_LOGO = 'images/mex-logo.svg'
+ORGANISATION_LOGO = "images/RKI-logo.svg"
+THEME_LOGO = "images/mex-logo.svg"
 
 # Invenio-App-RDM
 # ===============
 # See https://github.com/inveniosoftware/invenio-app-rdm/blob/master/invenio_app_rdm/config.py
 
 # Instance's theme entrypoint file. Path relative to the ``assets/`` folder.
-INSTANCE_THEME_FILE = './less/theme.less'
+INSTANCE_THEME_FILE = "./less/theme.less"
 
 # Email address for administrator emails (like file checksum alerts)
 APP_RDM_ADMIN_EMAIL_RECIPIENT = "mex@rki.de"
@@ -123,17 +129,19 @@ APP_RDM_DEPOSIT_FORM_DEFAULTS = {
         {
             "id": "cc-by-4.0",
             "title": "Creative Commons Attribution 4.0 International",
-            "description": ("The Creative Commons Attribution license allows "
-                            "re-distribution and re-use of a licensed work "
-                            "on the condition that the creator is "
-                            "appropriately credited."),
+            "description": (
+                "The Creative Commons Attribution license allows "
+                "re-distribution and re-use of a licensed work "
+                "on the condition that the creator is "
+                "appropriately credited."
+            ),
             "link": "https://creativecommons.org/licenses/by/4.0/legalcode",
         }
     ],
     "publisher": "mex-invenio",
 }
 
-APP_RDM_DEPOSIT_FORM_AUTOCOMPLETE_NAMES = 'search'  # "search_only" or "off"
+APP_RDM_DEPOSIT_FORM_AUTOCOMPLETE_NAMES = "search"  # "search_only" or "off"
 
 # Invenio-Records-Resources
 # =========================
@@ -166,7 +174,9 @@ SECURITY_REGISTERABLE = True  # local login: allow users to register
 SECURITY_RECOVERABLE = True  # local login: allow users to reset the password
 SECURITY_CHANGEABLE = True  # local login: allow users to change psw
 SECURITY_CONFIRMABLE = True  # local login: users can confirm e-mail address
-SECURITY_LOGIN_WITHOUT_CONFIRMATION = False  # require users to confirm email before being able to login
+SECURITY_LOGIN_WITHOUT_CONFIRMATION = (
+    False  # require users to confirm email before being able to login
+)
 
 # Invenio-OAuthclient
 # -------------------
@@ -176,12 +186,16 @@ OAUTHCLIENT_REMOTE_APPS = {}  # configure external login providers
 
 from invenio_oauthclient.views.client import auto_redirect_login
 
-ACCOUNTS_LOGIN_VIEW_FUNCTION = auto_redirect_login  # autoredirect to external login if enabled
+ACCOUNTS_LOGIN_VIEW_FUNCTION = (
+    auto_redirect_login  # autoredirect to external login if enabled
+)
 OAUTHCLIENT_AUTO_REDIRECT_TO_EXTERNAL_LOGIN = False  # autoredirect to external login
 
 # Invenio-UserProfiles
 # --------------------
-USERPROFILES_READ_ONLY = False  # allow users to change profile info (name, email, etc...)
+USERPROFILES_READ_ONLY = (
+    False  # allow users to change profile info (name, email, etc...)
+)
 
 # OAI-PMH
 # =======
@@ -194,16 +208,17 @@ OAISERVER_ADMIN_EMAILS = [
 ]
 
 # configure a custom OAI metadata format for MEx
-OAISERVER_METADATA_FORMATS['oai_dc'] = {
-    'serializer': 'mex_invenio.oai.mex:mex_dublincore_etree',
-    'schema': 'http://www.openarchives.org/OAI/2.0/oai_dc.xsd',
-    'namespace': 'http://www.openarchives.org/OAI/2.0/oai_dc/'}
+OAISERVER_METADATA_FORMATS["oai_dc"] = {
+    "serializer": "mex_invenio.oai.mex:mex_dublincore_etree",
+    "schema": "http://www.openarchives.org/OAI/2.0/oai_dc.xsd",
+    "namespace": "http://www.openarchives.org/OAI/2.0/oai_dc/",
+}
 
 # a list of custom fields that will be included in the OAI-PMH output as dc:source
-OAISERVER_SOURCES = ['mex:containedBy', 'mex:wasGeneratedBy', 'mex:usedIn']
+OAISERVER_SOURCES = ["mex:containedBy", "mex:wasGeneratedBy", "mex:usedIn"]
 
 # a list of custom fields that will be included in the OAI-PMH output as dc:relation
-OAISERVER_RELATIONS = ['mex:distribution', 'mex:isPartOf', 'mex:belongsTo']
+OAISERVER_RELATIONS = ["mex:distribution", "mex:isPartOf", "mex:belongsTo"]
 
 # Invenio-Search
 # --------------
@@ -218,7 +233,7 @@ USERS_RESOURCES_ADMINISTRATION_ENABLED = True
 
 # S3 config
 
-S3_DOWNLOAD_FOLDER = 's3_downloads'
+S3_DOWNLOAD_FOLDER = "s3_downloads"
 
 # If S3_ENDPOINT_URL is not set the script will use the default AWS S3 endpoint
 # S3_ENDPOINT_URL = 'http://localhost:9000'
@@ -226,17 +241,17 @@ S3_DOWNLOAD_FOLDER = 's3_downloads'
 # If S3_OBJECT_KEY is set, the script will download that specific file from S3
 # if it is not set the script will download the latest file in the bucket
 # NOTE that this requires permissions to list objects in the bucket
-S3_OBJECT_KEY = 'pub_small.ndjson'
+S3_OBJECT_KEY = "pub_small.ndjson"
 
 COMMUNITIES_GROUPS_ENABLED = False
 
 # Script log config
 # --------------
 
-IMPORT_LOG_FILE = 'logs/import_data.log'
-IMPORT_LOG_FORMAT = '%(asctime)s - %(levelname)s - (line: %(lineno)d) - %(message)s'
+IMPORT_LOG_FILE = "logs/import_data.log"
+IMPORT_LOG_FORMAT = "%(asctime)s - %(levelname)s - (line: %(lineno)d) - %(message)s"
 
-S3_LOG_FILE = 'logs/s3_manager.log'
+S3_LOG_FILE = "logs/s3_manager.log"
 S3_LOG_FORMAT = IMPORT_LOG_FORMAT
 
 # The value for the Datacite creator property in imported records
@@ -248,7 +263,15 @@ RECORD_METADATA_CREATOR = {
 }
 
 # MEx properties to use as record title
-RECORD_METADATA_TITLE_PROPERTIES = ['title', 'name', 'fullName', 'label', 'officialName', 'email', 'familyName']
+RECORD_METADATA_TITLE_PROPERTIES = [
+    "title",
+    "name",
+    "fullName",
+    "label",
+    "officialName",
+    "email",
+    "familyName",
+]
 
 # The default value for the Datacite title property in imported records
 # if it is not present in the MEx source record
@@ -272,18 +295,18 @@ RDM_FACETS = {
             # Field to filter on
             label=_("Resource types"),
             value_labels=VocabularyLabels("resourcetypes"),
-            allowed_values=["resource", "bibliographicresource", "variable", "activity"]
+            allowed_values=[
+                "resource",
+                "bibliographicresource",
+                "variable",
+                "activity",
+            ],
         ),
-        "ui": {
-            "field": "resource_type.id"
-        },
+        "ui": {"field": "resource_type.id"},
     },
 }
 
-RDM_SEARCH = {
-    **RDM_SEARCH,
-    "facets": ["restricted_resource_type"]
-}
+RDM_SEARCH = {**RDM_SEARCH, "facets": ["restricted_resource_type"]}
 
 # ---------- UI --------------
 
@@ -339,7 +362,7 @@ FIELD_LABELS_UI = {
     "mex:title": "Title",
     "mex:unitInCharge": "Unit In Charge",
     "mex:wasGeneratedBy": "Was Generated By",
-    "mex:usedIn": "Variable"
+    "mex:usedIn": "Variable",
 }
 
 RECORD_CARDS = {
@@ -353,8 +376,8 @@ RECORD_CARDS = {
                     "mex:unitInCharge",
                     "mex:contributor",
                     "mex:contributingUnit",
-                    "mex:externalPartner"
-                ]
+                    "mex:externalPartner",
+                ],
             },
             "theme": {
                 "title": "Theme & Keywords",
@@ -362,7 +385,7 @@ RECORD_CARDS = {
                 "properties": [
                     "mex:theme",
                     "mex:keyword",
-                ]
+                ],
             },
             "coverage": {
                 "title": "Data Representation & Coverage",
@@ -373,8 +396,8 @@ RECORD_CARDS = {
                     "mex:minTypicalAge",
                     "mex:maxTypicalAge",
                     "mex:populationCoverage",
-                    "mex:sizeOfDataBasis"
-                ]
+                    "mex:sizeOfDataBasis",
+                ],
             },
             "legal": {
                 "title": "Legal Basis & Data Provenance",
@@ -382,8 +405,8 @@ RECORD_CARDS = {
                 "properties": [
                     "mex:hasLegalBasis",
                     "mex:hasPersonalData",
-                    "mex:wasGeneratedBy"
-                ]
+                    "mex:wasGeneratedBy",
+                ],
             },
             "processing": {
                 "title": "Data Collection & Processing",
@@ -392,42 +415,32 @@ RECORD_CARDS = {
                     "mex:mex:resourceCreationMethod",
                     "mex:mex:accrualPeriodicity",
                     "mex:mex:anonymization/pseudonymization",
-                    "mex:mex:instrumentToolOrApparatus"
-                ]
+                    "mex:mex:instrumentToolOrApparatus",
+                ],
             },
             "methodology": {
                 "title": "Methodology",
                 "icon": "methodology.svg",
-                "properties": [
-                    "mex:method",
-                    "mex:methodDescription"
-                ]
+                "properties": ["mex:method", "mex:methodDescription"],
             },
             "publication": {
                 "title": "Related Publication & Further Documentation",
                 "icon": "publication.svg",
-                "properties": [
-                    "mex:publication",
-                    "mex:documentation"
-                ]
+                "properties": ["mex:publication", "mex:documentation"],
             },
             "childOf": {
                 "title": "Contained by",
                 "icon": "contained.svg",
                 "is_backwards_linked": True,
-                "properties": [
-                    "mex:isPartOf"
-                ]
-            }
+                "properties": ["mex:isPartOf"],
+            },
         },
         "right": {
             "contact": {
                 "title": "Contact",
                 "template": "contact.html",
                 "icon": "contact.svg",
-                "properties": [
-                    "mex:contact"
-                ]
+                "properties": ["mex:contact"],
             },
             "access": {
                 "title": "Access & Usage Rights",
@@ -437,34 +450,30 @@ RECORD_CARDS = {
                     "mex:accessRestriction",
                     "mex:doi",
                     "mex:license",
-                    "mex:rights"
-                ]
+                    "mex:rights",
+                ],
             },
             "files": {
                 "title": "Files",
                 "template": "files.html",
                 "icon": "distribution.svg",
-                "properties": [
-                    "mex:distribution"
-                ]
+                "properties": ["mex:distribution"],
             },
             "variables": {
                 "title": "Variables",
                 "template": "variables.html",
                 "icon": "variables.svg",
                 "is_backwards_linked": True,
-                "properties": [
-                    "mex:usedIn"
-                ]
-            }
-        }
+                "properties": ["mex:usedIn"],
+            },
+        },
     }
 }
 
 CUSTOM_FIELDS_UI_TYPES = {
-    item['field']: item['props']['type']
+    item["field"]: item["props"]["type"]
     for section in RDM_CUSTOM_FIELDS_UI
-    for item in section['fields']
+    for item in section["fields"]
 }
 
 # custom updates
@@ -478,7 +487,7 @@ DOI_URL = "https://dx.doi.org/"
 
 IS_ACCESS_STATUS_OPEN = {
     "https://mex.rki.de/item/access-restriction-1": True,
-    "https://mex.rki.de/item/access-restriction-2": False
+    "https://mex.rki.de/item/access-restriction-2": False,
 }
 
 APP_RDM_DETAIL_SIDE_BAR_TEMPLATES = [
@@ -502,45 +511,24 @@ LINKED_RECORDS_FIELDS = {
         "mex:contact": {
             "fields": ["mex:name", "mex:fullName", "mex:familyName", "mex:email"]
         },
-        "mex:isPartOf": {
-            "fields": ["mex:title"]
-        },
-        "mex:creator": {
-            "fields": ["mex:fullName", "mex:familyName", "mex:email"]
-        },
-        "mex:contributor": {
-            "fields": ["mex:fullName", "mex:familyName", "mex:email"]
-        },
-        "mex:unitInCharge": {
-            "fields": ["mex:name"]
-        },
-        "mex:contributingUnit": {
-            "fields": ["mex:name"]
-        },
-        "mex:externalPartner": {
-            "fields": ["mex:officialName"]
-        },
-        "mex:wasGeneratedBy": {
-            "fields": ["mex:title"]
-        },
-        "mex:publication": {
-            "fields": ["mex:title"]
-        },
-        "mex:distribution": {
-            "fields": ["mex:title"]
-        }
+        "mex:isPartOf": {"fields": ["mex:title"]},
+        "mex:creator": {"fields": ["mex:fullName", "mex:familyName", "mex:email"]},
+        "mex:contributor": {"fields": ["mex:fullName", "mex:familyName", "mex:email"]},
+        "mex:unitInCharge": {"fields": ["mex:name"]},
+        "mex:contributingUnit": {"fields": ["mex:name"]},
+        "mex:externalPartner": {"fields": ["mex:officialName"]},
+        "mex:wasGeneratedBy": {"fields": ["mex:title"]},
+        "mex:publication": {"fields": ["mex:title"]},
+        "mex:distribution": {"fields": ["mex:title"]},
     }
 }
 
 RECORDS_LINKED_BACKWARDS = {
-    "resource": {
-        "mex:isPartOf": "mex:title",
-        "mex:usedIn": "mex:label"
-    }
+    "resource": {"mex:isPartOf": "mex:title", "mex:usedIn": "mex:label"}
 }
 
 RECORD_SPECIAL_FIELDS = {
     "RESOURCE_TYPE_SPECIFIC": "mex:resourceTypeSpecific",
     "RESOURCE_TYPE_GENERAL": "mex:resourceTypeGeneral",
-    "ACCESS_RESTRICTION": "mex:accessRestriction"
+    "ACCESS_RESTRICTION": "mex:accessRestriction",
 }

--- a/site/mex_invenio/custom_facets.py
+++ b/site/mex_invenio/custom_facets.py
@@ -1,5 +1,6 @@
 from invenio_records_resources.services.records.facets import NestedTermsFacet
 
+
 class RestrictedTermsFacet(NestedTermsFacet):
     """Facet that only displays specific values."""
 
@@ -8,7 +9,9 @@ class RestrictedTermsFacet(NestedTermsFacet):
         super().__init__(field=field, label=label, **kwargs)
         self.allowed_values = set(allowed_values) if allowed_values else None
 
-    def get_labelled_values(self, data, filter_values, bucket_label=True, key_prefix=None):
+    def get_labelled_values(
+        self, data, filter_values, bucket_label=True, key_prefix=None
+    ):
         """Get an unlabelled version of the bucket, filtered by allowed values."""
         out = []
         label_map = self.get_label_mapping(data.buckets)
@@ -27,7 +30,10 @@ class RestrictedTermsFacet(NestedTermsFacet):
                 }
                 if "inner" in bucket:
                     bucket_out["inner"] = self.get_labelled_values(
-                        bucket.inner, filter_values, bucket_label=False, key_prefix=full_key
+                        bucket.inner,
+                        filter_values,
+                        bucket_label=False,
+                        key_prefix=full_key,
                     )
                 out.append(bucket_out)
 

--- a/site/mex_invenio/custom_fields/custom_fields.py
+++ b/site/mex_invenio/custom_fields/custom_fields.py
@@ -1,4 +1,8 @@
-from invenio_records_resources.services.custom_fields import TextCF, EDTFDateStringCF, IntegerCF
+from invenio_records_resources.services.custom_fields import (
+    TextCF,
+    EDTFDateStringCF,
+    IntegerCF,
+)
 
 from mex_invenio.custom_fields.link import LinkCF
 from mex_invenio.custom_fields.multilanguagetext import MultiLanguageTextCF
@@ -56,7 +60,7 @@ RDM_CUSTOM_FIELDS = [
     MultiLanguageTextCF(name="mex:hasLegalBasis", multiple=True),
     TextCF(name="mex:hasPersonalData"),
     TextCF(name="mex:icd10code", multiple=True),
-    TextCF(name="mex:identifier", field_args={'required': True}),
+    TextCF(name="mex:identifier", field_args={"required": True}),
     MultiLanguageTextCF(name="mex:instrumentToolOrApparatus", multiple=True),
     TextCF(name="mex:involvedPerson", multiple=True),
     TextCF(name="mex:involvedUnit", multiple=True),
@@ -126,349 +130,795 @@ RDM_CUSTOM_FIELDS = [
 ]
 
 RDM_CUSTOM_FIELDS_UI = [
-    {'fields': [
-        {'field': 'mex:abstract',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'An account of the publication.'}},
-        {'field': 'mex:accessPlatform',
-         'props': {'type': '/schema/entities/access-platform#/identifier',
-                   'description': 'A platform from which the resource can be accessed.'}},
-        {'field': 'mex:accessRestriction',
-         'props': {'type': '/schema/entities/concept#/identifier',
-                   'description': 'Indicates how access to the publication is restricted.'}},
-        {'field': 'mex:accessService',
-         'props': {'type': '/schema/entities/access-platform#/identifier',
-                   'description': 'A data service that gives access to the distribution of the dataset (DCAT, 2020-02-04).'}},
-        {'field': 'mex:accessURL',
-         'props': {'type': '/schema/fields/link',
-                   'description': 'A URL of the resource that gives access to a distribution of the dataset. E.g. landing page, feed, SPARQL endpoint (DCAT, 2020-02-04).'}},
-        {'field': 'mex:accrualPeriodicity',
-         'props': {'type': '/schema/entities/concept#/identifier',
-                   'description': 'The frequency with which items are added to a collection.'}},
-        {'field': 'mex:activityType',
-         'props': {'type': '/schema/entities/concept#/identifier',
-                   'description': 'The type of the activity.'}},
-        {'field': 'mex:affiliation',
-         'props': {'type': '/schema/entities/organization#/identifier',
-                   'description': 'An organization that the described person is affiliated with.'}},
-        {'field': 'mex:alternateIdentifier',
-         'props': {'type': 'string',
-                   'description': 'Another identifier used for the reference.'}},
-        {'field': 'mex:alternativeName',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'An alternative name for the organization'}},
-        {'field': 'mex:alternativeTitle',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'Another title for the publication.'}},
-        {'field': 'mex:anonymizationPseudonymization',
-         'props': {'type': '/schema/entities/concept#/identifier',
-                   'description': 'Indicates whether the data has been anonymized and/or pseudonymized.'}},
-        {'field': 'mex:belongsTo',
-         'props': {'type': '/schema/entities/variable-group#/identifier',
-                   'description': 'The variable group, the described variable is part of. Used to group variables together, depending on how they are structured in the primary source.'}},
-        {'field': 'mex:bibliographicResourceType',
-         'props': {'type': '/schema/entities/concept#/identifier',
-                   'description': 'The type of bibliographic resource.'}},
-        {'field': 'mex:codingSystem',
-         'props': {'type': 'string',
-                   'description': 'An established standard to which the described resource conforms (DCT, 2020-01-20).'}},
-        {'field': 'mex:conformsTo',
-         'props': {'type': 'string',
-                   'description': 'Standards used in the creation, analysis or transmission of the resource.'}},
-        {'field': 'mex:contact',
-         'props': {'type': '/schema/entities/organizational-unit#/identifier',
-                   'description': 'An agent that serves as a contact for the resource.'}},
-        {'field': 'mex:containedBy',
-         'props': {'type': '/schema/entities/resource#/identifier',
-                   'description': 'The resource, the variable group is contained by. Used to connect a variable group to its resource.'}},
-        {'field': 'mex:contributingUnit',
-         'props': {'type': '/schema/entities/organizational-unit#/identifier',
-                   'description': 'An organizational unit of RKI, that is contributing to the publication.'}},
-        {'field': 'mex:contributor',
-         'props': {'type': '/schema/entities/person#/identifier',
-                   'description': ' A person involved in the creation of the resource.'}},
-        {'field': 'mex:created',
-         'props': {'type': 'string',
-                   'description': 'Date of creation of the resource'}},
-        {'field': 'mex:creator',
-         'props': {'type': '/schema/entities/person#/identifier',
-                   'description': 'The author of the publication.'}},
-        {'field': 'mex:dataType',
-         'props': {'type': 'string',
-                   'description': 'The defined data type of the variable.'}},
-        {'field': 'mex:description',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'A description of the variable. How the variable is defined in the primary source.'}},
-        {'field': 'mex:distribution',
-         'props': {'type': '/schema/entities/distribution#/identifier',
-                   'description': 'An available distribution of the publication (DCAT, 2020-02-04)'}},
-        {'field': 'mex:documentation',
-         'props': {'type': '/schema/fields/link',
-                   'description': 'A link to a document documenting the resource.'}},
-        {'field': 'mex:doi',
-         'props': {'type': 'string',
-                   'description': 'The Digital Object Identifier (DOI) of the publication.'}},
-        {'field': 'mex:downloadURL',
-         'props': {'type': '/schema/fields/link',
-                   'description': 'The URL of the downloadable file in a given format. E.g. CSV file or RDF file. The format is indicated by the distribution\'s `dcat:mediaType` (DCAT, 2020-02-04).'}},
-        {'field': 'mex:edition',
-         'props': {'type': 'string',
-                   'description': 'The edition of the publication.'}},
-        {'field': 'mex:editor',
-         'props': {'type': '/schema/entities/person#/identifier',
-                   'description': 'The editor of the publication.'}},
-        {'field': 'mex:editorOfSeries',
-         'props': {'type': '/schema/entities/person#/identifier',
-                   'description': 'The editor of the series.'}},
-        {'field': 'mex:email',
-         'props': {'type': 'string',
-                   'description': 'The email address through which the person can be contacted.'}},
-        {'field': 'mex:end',
-         'props': {'type': 'string',
-                   'description': '(Planned) end of the activity.'}},
-        {'field': 'mex:endpointDescription',
-         'props': {'type': '/schema/fields/link',
-                   'description': 'A description of the services available via the end-points, including their operations, parameters etc.'}},
-        {'field': 'mex:endpointType',
-         'props': {'type': '/schema/entities/concept#/identifier',
-                   'description': 'The type of endpoint, e.g. REST.'}},
-        {'field': 'mex:endpointURL',
-         'props': {'type': '/schema/fields/link',
-                   'description': 'The root location or primary endpoint of the service (a Web-resolvable IRI)'}},
-        {'field': 'mex:externalAssociate',
-         'props': {'type': '/schema/entities/organization#/identifier',
-                   'description': 'An external institution or person, that is associated with the activity.'}},
-        {'field': 'mex:externalPartner',
-         'props': {'type': '/schema/entities/organization#/identifier',
-                   'description': 'An external organization that is somehow involved in the creation of the resource.'}},
-        {'field': 'mex:familyName',
-         'props': {'type': 'string',
-                   'description': 'The name inherited from the family.'}},
-        {'field': 'mex:fullName',
-         'props': {'type': 'string',
-                   'description': 'The full name of a person. Also used if the naming schema (given name and family name) does not apply to the name.'}},
-        {'field': 'mex:funderOrCommissioner',
-         'props': {'type': '/schema/entities/organization#/identifier',
-                   'description': 'An agent, that has either funded or commissioned the activity.'}},
-        {'field': 'mex:fundingProgram',
-         'props': {'type': 'string',
-                   'description': 'The program in which the activity is funded, e.g. Horizon2020.'}},
-        {'field': 'mex:geprisId',
-         'props': {'type': 'string',
-                   'description': 'Identifier from GEPRIS authority file.'}},
-        {'field': 'mex:givenName',
-         'props': {'type': 'string',
-                   'description': 'The name given to the person e.g. by their parents.'}},
-        {'field': 'mex:gndId',
-         'props': {'type': 'string',
-                   'description': 'An identifier from the German authority file named Gemeinsame Normdatei (GND), curated by the German National Library (DNB).'}},
-        {'field': 'mex:hasLegalBasis',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'The legal basis used to justify processing of personal data. Legal basis (plural: legal bases) are defined by legislations and regulations, whose applicability is usually restricted to specific jurisdictions which can be represented using dpv:hasJurisdiction or dpv:hasLaw. Legal basis can be used without such declarations, e.g. \'Consent\', however their interpretation will require association with a law, e.g. \'EU GDPR\'.'}},
-        {'field': 'mex:hasPersonalData',
-         'props': {'type': '/schema/entities/concept#/identifier',
-                   'description': 'Indicates, if a resource contains data directly or indirectly associated or related to an individual.'}},
-        {'field': 'mex:icd10code',
-         'props': {'type': 'string',
-                   'description': 'A concept from ICD-10.'}},
-        {'field': 'mex:identifier',
-         'props': {'type': '/schema/fields/identifier',
-                   'description': 'An unambiguous reference to the resource within a given context. Persistent identifiers should be provided as HTTP URIs (DCT, 2020-01-20).'}},
-        {'field': 'mex:instrumentToolOrApparatus',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'Instrument, tool, or apparatus used in the research, analysis, observation, or processing of the object that is the subject of this resource.'}},
-        {'field': 'mex:involvedPerson',
-         'props': {'type': '/schema/entities/person#/identifier',
-                   'description': 'A person involved in the activity.'}},
-        {'field': 'mex:involvedUnit',
-         'props': {'type': '/schema/entities/organizational-unit#/identifier',
-                   'description': 'An organizational unit that is involved in the activity.'}},
-        {'field': 'mex:isPartOf',
-         'props': {'type': '/schema/entities/resource#/identifier',
-                   'description': 'A related resource, in which the described resource is physically or logically included.'}},
-        {'field': 'mex:isPartOfActivity',
-         'props': {'type': '/schema/entities/activity#/identifier',
-                   'description': 'Another activity, this activity is part of.'}},
-        {'field': 'mex:isbnIssn',
-         'props': {'type': 'string',
-                   'description': 'Either the ISBN (for books) or ISSN (for periodicals) of the publication.'}},
-        {'field': 'mex:isniId',
-         'props': {'type': 'string',
-                   'description': 'The ISNI (International Standard Name Identifier) of the organization.'}},
-        {'field': 'mex:issue',
-         'props': {'type': 'string',
-                   'description': 'The issue of the periodical.'}},
-        {'field': 'mex:issued',
-         'props': {'type': 'string',
-                   'description': 'Date of formal issuance of the publication (DCT, 2020-01-20).'}},
-        {'field': 'mex:journal',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'The periodical in which the article was published.'}},
-        {'field': 'mex:keyword',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'A keyword or tag describing the resource (DCAT, 2020-02-04).'}},
-        {'field': 'mex:label',
-         'props': {'type': '/schema/fields/text'}},
-        {'field': 'mex:landingPage',
-         'props': {'type': '/schema/fields/link',
-                   'description': 'A Web page that can be navigated to in a Web browser to gain access to the catalog, a dataset, its distributions and/or additional information.'}},
-        {'field': 'mex:language',
-         'props': {'type': '/schema/entities/concept#/identifier',
-                   'description': 'The language in which the publication was written.'}},
-        {'field': 'mex:license',
-         'props': {'type': '/schema/entities/concept#/identifier',
-                   'description': 'A legal document giving official permission to do something with the publication (DCT, 2020-01-20).'}},
-        {'field': 'mex:loincId',
-         'props': {'type': 'string',
-                   'description': 'A concept from LOINC.'}},
-        {'field': 'mex:maxTypicalAge',
-         'props': {'type': 'string',
-                   'description': 'Specifies the maximum age of the population within the data collection, expressed in years.'}},
-        {'field': 'mex:mediaType',
-         'props': {'type': '/schema/entities/concept#/identifier',
-                   'description': 'The media type of the distribution as defined by IANA media types (DCAT, 2020-02-04).'}},
-        {'field': 'mex:memberOf',
-         'props': {'type': '/schema/entities/organizational-unit#/identifier',
-                   'description': 'Organizational unit at RKI the person is associated with.'}},
-        {'field': 'mex:meshId',
-         'props': {'type': 'string',
-                   'description': 'A concept from MeSH.'}},
-        {'field': 'mex:method',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'Method used in the research, analysis, observation or processing of the object that is subject to the resource.'}},
-        {'field': 'mex:methodDescription',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'The description of the method, that was used to research, analysis, observation or processing of the object that was subject to the resource.'}},
-        {'field': 'mex:minTypicalAge',
-         'props': {'type': 'string',
-                   'description': 'Specifies the minimum age of the population within the data collection, expressed in years.'}},
-        {'field': 'mex:modified',
-         'props': {'type': 'string',
-                   'description': 'Date on which the resource was changed.'}},
-        {'field': 'mex:name',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'The official name of the organizational unit.'}},
-        {'field': 'mex:officialName',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'The official name of the organization.'}},
-        {'field': 'mex:orcidId',
-         'props': {'type': 'string',
-                   'description': 'Identifier of a person from the ORCID authority file.'}},
-        {'field': 'mex:pages',
-         'props': {'type': 'string',
-                   'description': 'The range of pages or a single page.'}},
-        {'field': 'mex:parentUnit',
-         'props': {'type': '/schema/entities/organizational-unit#/identifier',
-                   'description': 'The described unit is a subunit of another organizational unit.'}},
-        {'field': 'mex:populationCoverage',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'The type of population common to all subjects of the data collection.'}},
-        {'field': 'mex:publication',
-         'props': {'type': '/schema/entities/bibliographic-resource#/identifier',
-                   'description': 'A publication that deals with the research, analysis, observation or processing of the object that was subject to the resource, e.g. a research paper.'}},
-        {'field': 'mex:publicationPlace',
-         'props': {'type': 'string',
-                   'description': 'The place where the document was issued.'}},
-        {'field': 'mex:publicationYear',
-         'props': {'type': 'string',
-                   'description': 'The year in which the publication was issued.'}},
-        {'field': 'mex:publisher',
-         'props': {'type': '/schema/entities/organization#/identifier',
-                   'description': 'An entity responsible for making the publication available (DCT, 2020-01-20).'}},
-        {'field': 'mex:qualityInformation',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'Some information about the quality of the resource.'}},
-        {'field': 'mex:repositoryURL',
-         'props': {'type': '/schema/fields/link',
-                   'description': 'The handle of the publication in the repository, where the publication is stored.'}},
-        {'field': 'mex:resourceCreationMethod',
-         'props': {'type': '/schema/entities/concept#/identifier',
-                   'description': 'Method how the resource was created.'}},
-        {'field': 'mex:resourceTypeGeneral',
-         'props': {'type': '/schema/entities/concept#/identifier',
-                   'description': 'General type of the resource.'}},
-        {'field': 'mex:resourceTypeSpecific',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'A term describing the specific nature of the resource. A more precise term than given by the property \'resourceTypeGeneral\'.'}},
-        {'field': 'mex:responsibleUnit',
-         'props': {'type': '/schema/entities/organizational-unit#/identifier',
-                   'description': 'A unit, that is responsible for the activity.'}},
-        {'field': 'mex:rights',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'Information about rights held in and over the resource as well as rights about the possibilities of the usage of the resource.'}},
-        {'field': 'mex:rorId',
-         'props': {'type': 'string',
-                   'description': 'An identifier of the Research Organization Registry (ROR).'}},
-        {'field': 'mex:section',
-         'props': {'type': 'string',
-                   'description': 'The name of the chapter of the publication, the book section belongs to.'}},
-        {'field': 'mex:shortName',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'A short name or abbreviation of the organization.'}},
-        {'field': 'mex:sizeOfDataBasis',
-         'props': {'type': 'string',
-                   'description': 'The size of the underlying data basis, e.g. for studies: the size of the sample.'}},
-        {'field': 'mex:spatial',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'Spatial coverage of the resource.'}},
-        {'field': 'mex:start',
-         'props': {'type': 'string',
-                   'description': 'The start of the activity.'}},
-        {'field': 'mex:stateOfDataProcessing',
-         'props': {'type': '/schema/entities/concept#/identifier',
-                   'description': 'The processing state of the data, e.g. raw or aggregated.'}},
-        {'field': 'mex:subtitle',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'The subtitle of the publication.'}},
-        {'field': 'mex:succeeds',
-         'props': {'type': '/schema/entities/activity#/identifier',
-                   'description': 'Another activity, that ended with the start of the described activity. A follow-up activity.'}},
-        {'field': 'mex:technicalAccessibility',
-         'props': {'type': '/schema/entities/concept#/identifier',
-                   'description': 'Indicates form if the platform can be accessed only within RKI network (internally) or if the platform is accessible publicly (externally).'}},
-        {'field': 'mex:temporal',
-         'props': {'type': 'string',
-                   'description': 'Temporal coverage of the resource.'}},
-        {'field': 'mex:theme',
-         'props': {'type': '/schema/entities/concept#/identifier',
-                   'description': 'A main category of the resource. A resource can have multiple themes.'}},
-        {'field': 'mex:title',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'The full title of the publication.'}},
-        {'field': 'mex:titleOfBook',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'The title of the book in which the book section is published.'}},
-        {'field': 'mex:titleOfSeries',
-         'props': {'type': '/schema/fields/text',
-                   'description': 'The title of the book series, the book belongs to.'}},
-        {'field': 'mex:unitInCharge',
-         'props': {'type': '/schema/entities/organizational-unit#/identifier',
-                   'description': 'This property refers to agents who assume responsibility and accountability for the resource and its appropriate maintenance.'}},
-        {'field': 'mex:unitOf',
-         'props': {'type': '/schema/entities/organization#/identifier',
-                   'description': 'Indicates an organization of which this unit is a part, e.g. a department within a larger organization.'}},
-        {'field': 'mex:usedIn',
-         'props': {'type': '/schema/entities/resource#/identifier',
-                   'description': 'The resource, the variable is used in.'}},
-        {'field': 'mex:valueSet',
-         'props': {'type': 'string',
-                   'description': 'A set of predefined values as given in the primary source.'}},
-        {'field': 'mex:viafId',
-         'props': {'type': 'string',
-                   'description': 'Identifier from VIAF (Virtual Authority File).'}},
-        {'field': 'mex:volume',
-         'props': {'type': 'string',
-                   'description': 'The volume of the periodical.'}},
-        {'field': 'mex:volumeOfSeries',
-         'props': {'type': 'string',
-                   'description': 'The volume of the periodical series.'}},
-        {'field': 'mex:wasGeneratedBy',
-         'props': {'type': '/schema/entities/activity#/identifier',
-                   'description': 'Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation.'}},
-        {'field': 'mex:website',
-         'props': {'type': '/schema/fields/link',
-                   'description': 'A web presentation of the activity, e.g. on the RKI homepage.'}},
-        {'field': 'mex:wikidataId',
-         'props': {'type': 'string',
-                   'description': 'Identifier from Wikidata.'}},
-    ]}]
+    {
+        "fields": [
+            {
+                "field": "mex:abstract",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "An account of the publication.",
+                },
+            },
+            {
+                "field": "mex:accessPlatform",
+                "props": {
+                    "type": "/schema/entities/access-platform#/identifier",
+                    "description": "A platform from which the resource can be accessed.",
+                },
+            },
+            {
+                "field": "mex:accessRestriction",
+                "props": {
+                    "type": "/schema/entities/concept#/identifier",
+                    "description": "Indicates how access to the publication is restricted.",
+                },
+            },
+            {
+                "field": "mex:accessService",
+                "props": {
+                    "type": "/schema/entities/access-platform#/identifier",
+                    "description": "A data service that gives access to the distribution of the dataset (DCAT, 2020-02-04).",
+                },
+            },
+            {
+                "field": "mex:accessURL",
+                "props": {
+                    "type": "/schema/fields/link",
+                    "description": "A URL of the resource that gives access to a distribution of the dataset. E.g. landing page, feed, SPARQL endpoint (DCAT, 2020-02-04).",
+                },
+            },
+            {
+                "field": "mex:accrualPeriodicity",
+                "props": {
+                    "type": "/schema/entities/concept#/identifier",
+                    "description": "The frequency with which items are added to a collection.",
+                },
+            },
+            {
+                "field": "mex:activityType",
+                "props": {
+                    "type": "/schema/entities/concept#/identifier",
+                    "description": "The type of the activity.",
+                },
+            },
+            {
+                "field": "mex:affiliation",
+                "props": {
+                    "type": "/schema/entities/organization#/identifier",
+                    "description": "An organization that the described person is affiliated with.",
+                },
+            },
+            {
+                "field": "mex:alternateIdentifier",
+                "props": {
+                    "type": "string",
+                    "description": "Another identifier used for the reference.",
+                },
+            },
+            {
+                "field": "mex:alternativeName",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "An alternative name for the organization",
+                },
+            },
+            {
+                "field": "mex:alternativeTitle",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "Another title for the publication.",
+                },
+            },
+            {
+                "field": "mex:anonymizationPseudonymization",
+                "props": {
+                    "type": "/schema/entities/concept#/identifier",
+                    "description": "Indicates whether the data has been anonymized and/or pseudonymized.",
+                },
+            },
+            {
+                "field": "mex:belongsTo",
+                "props": {
+                    "type": "/schema/entities/variable-group#/identifier",
+                    "description": "The variable group, the described variable is part of. Used to group variables together, depending on how they are structured in the primary source.",
+                },
+            },
+            {
+                "field": "mex:bibliographicResourceType",
+                "props": {
+                    "type": "/schema/entities/concept#/identifier",
+                    "description": "The type of bibliographic resource.",
+                },
+            },
+            {
+                "field": "mex:codingSystem",
+                "props": {
+                    "type": "string",
+                    "description": "An established standard to which the described resource conforms (DCT, 2020-01-20).",
+                },
+            },
+            {
+                "field": "mex:conformsTo",
+                "props": {
+                    "type": "string",
+                    "description": "Standards used in the creation, analysis or transmission of the resource.",
+                },
+            },
+            {
+                "field": "mex:contact",
+                "props": {
+                    "type": "/schema/entities/organizational-unit#/identifier",
+                    "description": "An agent that serves as a contact for the resource.",
+                },
+            },
+            {
+                "field": "mex:containedBy",
+                "props": {
+                    "type": "/schema/entities/resource#/identifier",
+                    "description": "The resource, the variable group is contained by. Used to connect a variable group to its resource.",
+                },
+            },
+            {
+                "field": "mex:contributingUnit",
+                "props": {
+                    "type": "/schema/entities/organizational-unit#/identifier",
+                    "description": "An organizational unit of RKI, that is contributing to the publication.",
+                },
+            },
+            {
+                "field": "mex:contributor",
+                "props": {
+                    "type": "/schema/entities/person#/identifier",
+                    "description": " A person involved in the creation of the resource.",
+                },
+            },
+            {
+                "field": "mex:created",
+                "props": {
+                    "type": "string",
+                    "description": "Date of creation of the resource",
+                },
+            },
+            {
+                "field": "mex:creator",
+                "props": {
+                    "type": "/schema/entities/person#/identifier",
+                    "description": "The author of the publication.",
+                },
+            },
+            {
+                "field": "mex:dataType",
+                "props": {
+                    "type": "string",
+                    "description": "The defined data type of the variable.",
+                },
+            },
+            {
+                "field": "mex:description",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "A description of the variable. How the variable is defined in the primary source.",
+                },
+            },
+            {
+                "field": "mex:distribution",
+                "props": {
+                    "type": "/schema/entities/distribution#/identifier",
+                    "description": "An available distribution of the publication (DCAT, 2020-02-04)",
+                },
+            },
+            {
+                "field": "mex:documentation",
+                "props": {
+                    "type": "/schema/fields/link",
+                    "description": "A link to a document documenting the resource.",
+                },
+            },
+            {
+                "field": "mex:doi",
+                "props": {
+                    "type": "string",
+                    "description": "The Digital Object Identifier (DOI) of the publication.",
+                },
+            },
+            {
+                "field": "mex:downloadURL",
+                "props": {
+                    "type": "/schema/fields/link",
+                    "description": "The URL of the downloadable file in a given format. E.g. CSV file or RDF file. The format is indicated by the distribution's `dcat:mediaType` (DCAT, 2020-02-04).",
+                },
+            },
+            {
+                "field": "mex:edition",
+                "props": {
+                    "type": "string",
+                    "description": "The edition of the publication.",
+                },
+            },
+            {
+                "field": "mex:editor",
+                "props": {
+                    "type": "/schema/entities/person#/identifier",
+                    "description": "The editor of the publication.",
+                },
+            },
+            {
+                "field": "mex:editorOfSeries",
+                "props": {
+                    "type": "/schema/entities/person#/identifier",
+                    "description": "The editor of the series.",
+                },
+            },
+            {
+                "field": "mex:email",
+                "props": {
+                    "type": "string",
+                    "description": "The email address through which the person can be contacted.",
+                },
+            },
+            {
+                "field": "mex:end",
+                "props": {
+                    "type": "string",
+                    "description": "(Planned) end of the activity.",
+                },
+            },
+            {
+                "field": "mex:endpointDescription",
+                "props": {
+                    "type": "/schema/fields/link",
+                    "description": "A description of the services available via the end-points, including their operations, parameters etc.",
+                },
+            },
+            {
+                "field": "mex:endpointType",
+                "props": {
+                    "type": "/schema/entities/concept#/identifier",
+                    "description": "The type of endpoint, e.g. REST.",
+                },
+            },
+            {
+                "field": "mex:endpointURL",
+                "props": {
+                    "type": "/schema/fields/link",
+                    "description": "The root location or primary endpoint of the service (a Web-resolvable IRI)",
+                },
+            },
+            {
+                "field": "mex:externalAssociate",
+                "props": {
+                    "type": "/schema/entities/organization#/identifier",
+                    "description": "An external institution or person, that is associated with the activity.",
+                },
+            },
+            {
+                "field": "mex:externalPartner",
+                "props": {
+                    "type": "/schema/entities/organization#/identifier",
+                    "description": "An external organization that is somehow involved in the creation of the resource.",
+                },
+            },
+            {
+                "field": "mex:familyName",
+                "props": {
+                    "type": "string",
+                    "description": "The name inherited from the family.",
+                },
+            },
+            {
+                "field": "mex:fullName",
+                "props": {
+                    "type": "string",
+                    "description": "The full name of a person. Also used if the naming schema (given name and family name) does not apply to the name.",
+                },
+            },
+            {
+                "field": "mex:funderOrCommissioner",
+                "props": {
+                    "type": "/schema/entities/organization#/identifier",
+                    "description": "An agent, that has either funded or commissioned the activity.",
+                },
+            },
+            {
+                "field": "mex:fundingProgram",
+                "props": {
+                    "type": "string",
+                    "description": "The program in which the activity is funded, e.g. Horizon2020.",
+                },
+            },
+            {
+                "field": "mex:geprisId",
+                "props": {
+                    "type": "string",
+                    "description": "Identifier from GEPRIS authority file.",
+                },
+            },
+            {
+                "field": "mex:givenName",
+                "props": {
+                    "type": "string",
+                    "description": "The name given to the person e.g. by their parents.",
+                },
+            },
+            {
+                "field": "mex:gndId",
+                "props": {
+                    "type": "string",
+                    "description": "An identifier from the German authority file named Gemeinsame Normdatei (GND), curated by the German National Library (DNB).",
+                },
+            },
+            {
+                "field": "mex:hasLegalBasis",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "The legal basis used to justify processing of personal data. Legal basis (plural: legal bases) are defined by legislations and regulations, whose applicability is usually restricted to specific jurisdictions which can be represented using dpv:hasJurisdiction or dpv:hasLaw. Legal basis can be used without such declarations, e.g. 'Consent', however their interpretation will require association with a law, e.g. 'EU GDPR'.",
+                },
+            },
+            {
+                "field": "mex:hasPersonalData",
+                "props": {
+                    "type": "/schema/entities/concept#/identifier",
+                    "description": "Indicates, if a resource contains data directly or indirectly associated or related to an individual.",
+                },
+            },
+            {
+                "field": "mex:icd10code",
+                "props": {"type": "string", "description": "A concept from ICD-10."},
+            },
+            {
+                "field": "mex:identifier",
+                "props": {
+                    "type": "/schema/fields/identifier",
+                    "description": "An unambiguous reference to the resource within a given context. Persistent identifiers should be provided as HTTP URIs (DCT, 2020-01-20).",
+                },
+            },
+            {
+                "field": "mex:instrumentToolOrApparatus",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "Instrument, tool, or apparatus used in the research, analysis, observation, or processing of the object that is the subject of this resource.",
+                },
+            },
+            {
+                "field": "mex:involvedPerson",
+                "props": {
+                    "type": "/schema/entities/person#/identifier",
+                    "description": "A person involved in the activity.",
+                },
+            },
+            {
+                "field": "mex:involvedUnit",
+                "props": {
+                    "type": "/schema/entities/organizational-unit#/identifier",
+                    "description": "An organizational unit that is involved in the activity.",
+                },
+            },
+            {
+                "field": "mex:isPartOf",
+                "props": {
+                    "type": "/schema/entities/resource#/identifier",
+                    "description": "A related resource, in which the described resource is physically or logically included.",
+                },
+            },
+            {
+                "field": "mex:isPartOfActivity",
+                "props": {
+                    "type": "/schema/entities/activity#/identifier",
+                    "description": "Another activity, this activity is part of.",
+                },
+            },
+            {
+                "field": "mex:isbnIssn",
+                "props": {
+                    "type": "string",
+                    "description": "Either the ISBN (for books) or ISSN (for periodicals) of the publication.",
+                },
+            },
+            {
+                "field": "mex:isniId",
+                "props": {
+                    "type": "string",
+                    "description": "The ISNI (International Standard Name Identifier) of the organization.",
+                },
+            },
+            {
+                "field": "mex:issue",
+                "props": {
+                    "type": "string",
+                    "description": "The issue of the periodical.",
+                },
+            },
+            {
+                "field": "mex:issued",
+                "props": {
+                    "type": "string",
+                    "description": "Date of formal issuance of the publication (DCT, 2020-01-20).",
+                },
+            },
+            {
+                "field": "mex:journal",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "The periodical in which the article was published.",
+                },
+            },
+            {
+                "field": "mex:keyword",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "A keyword or tag describing the resource (DCAT, 2020-02-04).",
+                },
+            },
+            {"field": "mex:label", "props": {"type": "/schema/fields/text"}},
+            {
+                "field": "mex:landingPage",
+                "props": {
+                    "type": "/schema/fields/link",
+                    "description": "A Web page that can be navigated to in a Web browser to gain access to the catalog, a dataset, its distributions and/or additional information.",
+                },
+            },
+            {
+                "field": "mex:language",
+                "props": {
+                    "type": "/schema/entities/concept#/identifier",
+                    "description": "The language in which the publication was written.",
+                },
+            },
+            {
+                "field": "mex:license",
+                "props": {
+                    "type": "/schema/entities/concept#/identifier",
+                    "description": "A legal document giving official permission to do something with the publication (DCT, 2020-01-20).",
+                },
+            },
+            {
+                "field": "mex:loincId",
+                "props": {"type": "string", "description": "A concept from LOINC."},
+            },
+            {
+                "field": "mex:maxTypicalAge",
+                "props": {
+                    "type": "string",
+                    "description": "Specifies the maximum age of the population within the data collection, expressed in years.",
+                },
+            },
+            {
+                "field": "mex:mediaType",
+                "props": {
+                    "type": "/schema/entities/concept#/identifier",
+                    "description": "The media type of the distribution as defined by IANA media types (DCAT, 2020-02-04).",
+                },
+            },
+            {
+                "field": "mex:memberOf",
+                "props": {
+                    "type": "/schema/entities/organizational-unit#/identifier",
+                    "description": "Organizational unit at RKI the person is associated with.",
+                },
+            },
+            {
+                "field": "mex:meshId",
+                "props": {"type": "string", "description": "A concept from MeSH."},
+            },
+            {
+                "field": "mex:method",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "Method used in the research, analysis, observation or processing of the object that is subject to the resource.",
+                },
+            },
+            {
+                "field": "mex:methodDescription",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "The description of the method, that was used to research, analysis, observation or processing of the object that was subject to the resource.",
+                },
+            },
+            {
+                "field": "mex:minTypicalAge",
+                "props": {
+                    "type": "string",
+                    "description": "Specifies the minimum age of the population within the data collection, expressed in years.",
+                },
+            },
+            {
+                "field": "mex:modified",
+                "props": {
+                    "type": "string",
+                    "description": "Date on which the resource was changed.",
+                },
+            },
+            {
+                "field": "mex:name",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "The official name of the organizational unit.",
+                },
+            },
+            {
+                "field": "mex:officialName",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "The official name of the organization.",
+                },
+            },
+            {
+                "field": "mex:orcidId",
+                "props": {
+                    "type": "string",
+                    "description": "Identifier of a person from the ORCID authority file.",
+                },
+            },
+            {
+                "field": "mex:pages",
+                "props": {
+                    "type": "string",
+                    "description": "The range of pages or a single page.",
+                },
+            },
+            {
+                "field": "mex:parentUnit",
+                "props": {
+                    "type": "/schema/entities/organizational-unit#/identifier",
+                    "description": "The described unit is a subunit of another organizational unit.",
+                },
+            },
+            {
+                "field": "mex:populationCoverage",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "The type of population common to all subjects of the data collection.",
+                },
+            },
+            {
+                "field": "mex:publication",
+                "props": {
+                    "type": "/schema/entities/bibliographic-resource#/identifier",
+                    "description": "A publication that deals with the research, analysis, observation or processing of the object that was subject to the resource, e.g. a research paper.",
+                },
+            },
+            {
+                "field": "mex:publicationPlace",
+                "props": {
+                    "type": "string",
+                    "description": "The place where the document was issued.",
+                },
+            },
+            {
+                "field": "mex:publicationYear",
+                "props": {
+                    "type": "string",
+                    "description": "The year in which the publication was issued.",
+                },
+            },
+            {
+                "field": "mex:publisher",
+                "props": {
+                    "type": "/schema/entities/organization#/identifier",
+                    "description": "An entity responsible for making the publication available (DCT, 2020-01-20).",
+                },
+            },
+            {
+                "field": "mex:qualityInformation",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "Some information about the quality of the resource.",
+                },
+            },
+            {
+                "field": "mex:repositoryURL",
+                "props": {
+                    "type": "/schema/fields/link",
+                    "description": "The handle of the publication in the repository, where the publication is stored.",
+                },
+            },
+            {
+                "field": "mex:resourceCreationMethod",
+                "props": {
+                    "type": "/schema/entities/concept#/identifier",
+                    "description": "Method how the resource was created.",
+                },
+            },
+            {
+                "field": "mex:resourceTypeGeneral",
+                "props": {
+                    "type": "/schema/entities/concept#/identifier",
+                    "description": "General type of the resource.",
+                },
+            },
+            {
+                "field": "mex:resourceTypeSpecific",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "A term describing the specific nature of the resource. A more precise term than given by the property 'resourceTypeGeneral'.",
+                },
+            },
+            {
+                "field": "mex:responsibleUnit",
+                "props": {
+                    "type": "/schema/entities/organizational-unit#/identifier",
+                    "description": "A unit, that is responsible for the activity.",
+                },
+            },
+            {
+                "field": "mex:rights",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "Information about rights held in and over the resource as well as rights about the possibilities of the usage of the resource.",
+                },
+            },
+            {
+                "field": "mex:rorId",
+                "props": {
+                    "type": "string",
+                    "description": "An identifier of the Research Organization Registry (ROR).",
+                },
+            },
+            {
+                "field": "mex:section",
+                "props": {
+                    "type": "string",
+                    "description": "The name of the chapter of the publication, the book section belongs to.",
+                },
+            },
+            {
+                "field": "mex:shortName",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "A short name or abbreviation of the organization.",
+                },
+            },
+            {
+                "field": "mex:sizeOfDataBasis",
+                "props": {
+                    "type": "string",
+                    "description": "The size of the underlying data basis, e.g. for studies: the size of the sample.",
+                },
+            },
+            {
+                "field": "mex:spatial",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "Spatial coverage of the resource.",
+                },
+            },
+            {
+                "field": "mex:start",
+                "props": {
+                    "type": "string",
+                    "description": "The start of the activity.",
+                },
+            },
+            {
+                "field": "mex:stateOfDataProcessing",
+                "props": {
+                    "type": "/schema/entities/concept#/identifier",
+                    "description": "The processing state of the data, e.g. raw or aggregated.",
+                },
+            },
+            {
+                "field": "mex:subtitle",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "The subtitle of the publication.",
+                },
+            },
+            {
+                "field": "mex:succeeds",
+                "props": {
+                    "type": "/schema/entities/activity#/identifier",
+                    "description": "Another activity, that ended with the start of the described activity. A follow-up activity.",
+                },
+            },
+            {
+                "field": "mex:technicalAccessibility",
+                "props": {
+                    "type": "/schema/entities/concept#/identifier",
+                    "description": "Indicates form if the platform can be accessed only within RKI network (internally) or if the platform is accessible publicly (externally).",
+                },
+            },
+            {
+                "field": "mex:temporal",
+                "props": {
+                    "type": "string",
+                    "description": "Temporal coverage of the resource.",
+                },
+            },
+            {
+                "field": "mex:theme",
+                "props": {
+                    "type": "/schema/entities/concept#/identifier",
+                    "description": "A main category of the resource. A resource can have multiple themes.",
+                },
+            },
+            {
+                "field": "mex:title",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "The full title of the publication.",
+                },
+            },
+            {
+                "field": "mex:titleOfBook",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "The title of the book in which the book section is published.",
+                },
+            },
+            {
+                "field": "mex:titleOfSeries",
+                "props": {
+                    "type": "/schema/fields/text",
+                    "description": "The title of the book series, the book belongs to.",
+                },
+            },
+            {
+                "field": "mex:unitInCharge",
+                "props": {
+                    "type": "/schema/entities/organizational-unit#/identifier",
+                    "description": "This property refers to agents who assume responsibility and accountability for the resource and its appropriate maintenance.",
+                },
+            },
+            {
+                "field": "mex:unitOf",
+                "props": {
+                    "type": "/schema/entities/organization#/identifier",
+                    "description": "Indicates an organization of which this unit is a part, e.g. a department within a larger organization.",
+                },
+            },
+            {
+                "field": "mex:usedIn",
+                "props": {
+                    "type": "/schema/entities/resource#/identifier",
+                    "description": "The resource, the variable is used in.",
+                },
+            },
+            {
+                "field": "mex:valueSet",
+                "props": {
+                    "type": "string",
+                    "description": "A set of predefined values as given in the primary source.",
+                },
+            },
+            {
+                "field": "mex:viafId",
+                "props": {
+                    "type": "string",
+                    "description": "Identifier from VIAF (Virtual Authority File).",
+                },
+            },
+            {
+                "field": "mex:volume",
+                "props": {
+                    "type": "string",
+                    "description": "The volume of the periodical.",
+                },
+            },
+            {
+                "field": "mex:volumeOfSeries",
+                "props": {
+                    "type": "string",
+                    "description": "The volume of the periodical series.",
+                },
+            },
+            {
+                "field": "mex:wasGeneratedBy",
+                "props": {
+                    "type": "/schema/entities/activity#/identifier",
+                    "description": "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation.",
+                },
+            },
+            {
+                "field": "mex:website",
+                "props": {
+                    "type": "/schema/fields/link",
+                    "description": "A web presentation of the activity, e.g. on the RKI homepage.",
+                },
+            },
+            {
+                "field": "mex:wikidataId",
+                "props": {"type": "string", "description": "Identifier from Wikidata."},
+            },
+        ]
+    }
+]

--- a/site/mex_invenio/custom_fields/link.py
+++ b/site/mex_invenio/custom_fields/link.py
@@ -16,12 +16,16 @@ class LinkCF(BaseListCF):
             field_cls=fields.Nested,
             field_args=dict(
                 nested=dict(
-                    language=SanitizedUnicode(validate=validate.OneOf(choices=['en', 'de'])),
+                    language=SanitizedUnicode(
+                        validate=validate.OneOf(choices=["en", "de"])
+                    ),
                     title=SanitizedUnicode(),
-                    url=SanitizedUnicode(required=True, validate=validate.Length(min=1))
+                    url=SanitizedUnicode(
+                        required=True, validate=validate.Length(min=1)
+                    ),
                 )
             ),
-            **kwargs
+            **kwargs,
         )
 
     @property
@@ -29,11 +33,7 @@ class LinkCF(BaseListCF):
         """Return the mapping."""
         return {
             "properties": {
-                "language": {
-                    "type": "text"
-                },
-                "title": {
-                    "type": "text"
-                },
+                "language": {"type": "text"},
+                "title": {"type": "text"},
             }
         }

--- a/site/mex_invenio/custom_fields/multilanguagetext.py
+++ b/site/mex_invenio/custom_fields/multilanguagetext.py
@@ -16,11 +16,15 @@ class MultiLanguageTextCF(BaseListCF):
             field_cls=fields.Nested,
             field_args=dict(
                 nested=dict(
-                    language=SanitizedUnicode(validate=validate.OneOf(choices=['en', 'de'])),
-                    value=SanitizedUnicode(required=True, validate=validate.Length(min=1))
+                    language=SanitizedUnicode(
+                        validate=validate.OneOf(choices=["en", "de"])
+                    ),
+                    value=SanitizedUnicode(
+                        required=True, validate=validate.Length(min=1)
+                    ),
                 )
             ),
-            **kwargs
+            **kwargs,
         )
 
     @property
@@ -28,11 +32,7 @@ class MultiLanguageTextCF(BaseListCF):
         """Return the mapping."""
         return {
             "properties": {
-                "language": {
-                    "type": "text"
-                },
-                "value": {
-                    "type": "text"
-                },
+                "language": {"type": "text"},
+                "value": {"type": "text"},
             }
         }

--- a/site/mex_invenio/custom_fields/pref_labels.py
+++ b/site/mex_invenio/custom_fields/pref_labels.py
@@ -9,35 +9,35 @@ from mex_invenio.scripts.utils import compare_files
 
 def get_pref_labels():
     """Read and write pref labels from JSON files in the
-     vocabularies directory to a template accessible file."""
+    vocabularies directory to a template accessible file."""
 
     pref_labels = {}
-    template_dir = 'templates/semantic-ui/invenio_app_rdm/records/macros'
-    vocab_dir = 'site/mex_invenio/custom_fields/mex-model/mex/model/vocabularies'
-    existing_pref_labels = f'{template_dir}/pref_labels.jinja'
-    new_pref_labels = f'{template_dir}/new_pref_labels.jinja'
+    template_dir = "templates/semantic-ui/invenio_app_rdm/records/macros"
+    vocab_dir = "site/mex_invenio/custom_fields/mex-model/mex/model/vocabularies"
+    existing_pref_labels = f"{template_dir}/pref_labels.jinja"
+    new_pref_labels = f"{template_dir}/new_pref_labels.jinja"
 
     if not os.path.isdir(vocab_dir):
         return
 
     for vocab in os.listdir(vocab_dir):
-        with open(f'{vocab_dir}/{vocab}') as vocab_file:
+        with open(f"{vocab_dir}/{vocab}") as vocab_file:
             prefs = json.load(vocab_file)
             for pref in prefs:
-                identifier = pref.get('identifier')
-                pref_label = pref.get('prefLabel')
-                description = pref.get('description')
+                identifier = pref.get("identifier")
+                pref_label = pref.get("prefLabel")
+                description = pref.get("description")
 
                 if description:
                     # Concept-schemes.json contains a description of each concept
                     # it is metadata and not a prefLabel
-                    pref.pop('identifier')
+                    pref.pop("identifier")
                     pref_labels[identifier] = pref
 
                 else:
                     pref_labels[identifier] = pref_label
 
-    with open(new_pref_labels, 'w', encoding='utf-8') as template_file:
+    with open(new_pref_labels, "w", encoding="utf-8") as template_file:
         template_file.write("{% set pref_labels = ")
         template_file.write(json.dumps(pref_labels, indent=4))
         template_file.write(" %}")

--- a/site/mex_invenio/oai/mex.py
+++ b/site/mex_invenio/oai/mex.py
@@ -12,7 +12,7 @@ def dump_etree_helper(container_name, data, rules, nsmap, attrib):
     This function is a modified version of dcxml.xmlutils.dump_etree in order
     to support the xml:lang attrib.
     """
-    nsmap['xml'] = 'http://www.w3.org/XML/1998/namespace'
+    nsmap["xml"] = "http://www.w3.org/XML/1998/namespace"
     output = etree.Element(container_name, nsmap=nsmap, attrib=attrib)
 
     for rule in rules:
@@ -23,17 +23,21 @@ def dump_etree_helper(container_name, data, rules, nsmap, attrib):
 
         for d in data[rule]:
             if isinstance(d, dict):
-                element_data.append(d['value'])
+                element_data.append(d["value"])
             else:
                 element_data.append(d)
 
         element = rules[rule](rule, element_data)
 
         for e in element:
-            lang = [a['language'] for a in data[rule] if isinstance(a, dict) and a['value'] == e.text]
+            lang = [
+                a["language"]
+                for a in data[rule]
+                if isinstance(a, dict) and a["value"] == e.text
+            ]
 
             if lang:
-                e.set('{http://www.w3.org/XML/1998/namespace}lang', lang[0])
+                e.set("{http://www.w3.org/XML/1998/namespace}lang", lang[0])
             output.append(e)
 
     return output
@@ -47,72 +51,83 @@ def mex_dublincore_etree(pid, record, **serializer_kwargs):
     item = current_rdm_records_service.oai_result_item(g.identity, record["_source"])
     oai_record = item.to_dict()
 
-    obj = {'titles': [], 'identifiers': [oai_record['pids']['oai']['identifier']], 'creators': [], 'dates': [],
-           'descriptions': []}
+    obj = {
+        "titles": [],
+        "identifiers": [oai_record["pids"]["oai"]["identifier"]],
+        "creators": [],
+        "dates": [],
+        "descriptions": [],
+    }
 
-    cf = oai_record['custom_fields']
+    cf = oai_record["custom_fields"]
 
-    for t in current_app.config.get('RECORD_METADATA_TITLE_PROPERTIES', ''):
-        if f'mex:{t}' in cf:
-            obj['titles'].extend(cf[f'mex:{t}'])
+    for t in current_app.config.get("RECORD_METADATA_TITLE_PROPERTIES", ""):
+        if f"mex:{t}" in cf:
+            obj["titles"].extend(cf[f"mex:{t}"])
 
     # defaults to closedAccess, see
     # https://guidelines.openaire.eu/en/latest/literature/field_accesslevel.html
     # only set license to open if there is a license
-    if 'mex:license' in cf:
-        obj['rights'] = ['info:eu-repo/semantics/openAccess']
+    if "mex:license" in cf:
+        obj["rights"] = ["info:eu-repo/semantics/openAccess"]
 
     # not set by default, see
     # https://guidelines.openaire.eu/en/latest/literature/field_publicationtype.html
-    obj['types'] = ['info:eu-repo/semantics/other']
+    obj["types"] = ["info:eu-repo/semantics/other"]
 
     # mex:identifier is a required field
-    obj['identifiers'].append(cf['mex:identifier'])
+    obj["identifiers"].append(cf["mex:identifier"])
 
     # description and abstract get mapped to descriptions
-    for p in ['mex:description', 'mex:abstract']:
+    for p in ["mex:description", "mex:abstract"]:
         if p in cf:
-            obj['descriptions'].extend(cf[p])
+            obj["descriptions"].extend(cf[p])
 
-    if 'mex:creator' in cf:
+    if "mex:creator" in cf:
         # all records will have a creator because it's a mandatory field
         # that will be the config value of RECORD_METADATA_CREATOR
-        obj['creators'].extend(cf['mex:creator'])
+        obj["creators"].extend(cf["mex:creator"])
 
-    if 'mex:keyword' in cf:
-        obj['subjects'] = cf['mex:keyword']
+    if "mex:keyword" in cf:
+        obj["subjects"] = cf["mex:keyword"]
 
-    if 'mex:publisher' in cf:
-        obj['publishers'] = cf['mex:publisher']
+    if "mex:publisher" in cf:
+        obj["publishers"] = cf["mex:publisher"]
 
-    if 'mex:contact' in cf:
-        obj['contributors'] = cf['mex:contact']
+    if "mex:contact" in cf:
+        obj["contributors"] = cf["mex:contact"]
 
-    if 'mex:mediaType' in cf:
-        obj['formats'] = [cf['mex:mediaType']]
+    if "mex:mediaType" in cf:
+        obj["formats"] = [cf["mex:mediaType"]]
 
-    if 'mex:language' in cf:
-        obj['languages'] = cf['mex:language']
+    if "mex:language" in cf:
+        obj["languages"] = cf["mex:language"]
 
     dates = []
 
     # there seems to be a bug in how EDTFDateStringCF fields are serialized
     # they are serialized as lists, but should be strings
-    for date in ['mex:issued', 'mex:publicationYear', 'mex:created', 'mex:start', 'mex:end']:
+    for date in [
+        "mex:issued",
+        "mex:publicationYear",
+        "mex:created",
+        "mex:start",
+        "mex:end",
+    ]:
         if date in cf:
             if isinstance(cf[date], list):
-                dates.append(''.join(cf[date]))
+                dates.append("".join(cf[date]))
             else:
                 dates.append(cf[date])
 
     if dates:
-        obj['dates'].extend(dates)
+        obj["dates"].extend(dates)
 
     # sources, see
     # https://guidelines.openaire.eu/en/latest/literature/field_source.html
     sources = []
 
-    for source in current_app.config.get('OAISERVER_SOURCES', []):
+    for source in current_app.config.get("OAISERVER_SOURCES", []):
         if source in cf:
             if isinstance(cf[source], list):
                 sources.extend(cf[source])
@@ -123,7 +138,7 @@ def mex_dublincore_etree(pid, record, **serializer_kwargs):
     # https://guidelines.openaire.eu/en/latest/literature/field_relation.html
     relations = []
 
-    for relation in current_app.config.get('OAISERVER_RELATIONS', []):
+    for relation in current_app.config.get("OAISERVER_RELATIONS", []):
         if relation in cf:
             if isinstance(cf[relation], list):
                 relations.extend(cf[relation])
@@ -131,9 +146,9 @@ def mex_dublincore_etree(pid, record, **serializer_kwargs):
                 relations.append(cf[relation])
 
     if sources:
-        obj['sources'] = sources
+        obj["sources"] = sources
 
     if relations:
-        obj['relations'] = relations
+        obj["relations"] = relations
 
     return dump_etree_helper(container_element, obj, rules, ns, container_attribs)

--- a/site/mex_invenio/record/record.py
+++ b/site/mex_invenio/record/record.py
@@ -12,15 +12,15 @@ from invenio_pidstore.errors import (
     PIDMissingObjectError,
     PIDRedirectedError,
     PIDUnregistered,
-    PIDValueError
+    PIDValueError,
 )
 
 import json
 
 
 def _get_record_by_field(field_id, value):
-    escaped_field = field_id.replace(':', '\:')
-    search_query = f'custom_fields.{escaped_field}:{value}'
+    escaped_field = field_id.replace(":", "\:")
+    search_query = f"custom_fields.{escaped_field}:{value}"
     results = list(current_rdm_records_service.search(g.identity, q=search_query))
 
     return results or None
@@ -39,12 +39,10 @@ def _get_record_by_id(mex_id):
 
 
 class MexRecord(MethodView):
-
     def __init__(self):
         self.template = "invenio_app_rdm/records/detail.html"
 
     def get(self, mex_id):
-
         try:
             record = _get_record_by_id(mex_id)
         except PIDDoesNotExistError:
@@ -64,19 +62,19 @@ class MexRecord(MethodView):
         backwards_linked_records = {}
 
         if record_type in settings.LINKED_RECORDS_FIELDS:
-
             for field, props in settings.LINKED_RECORDS_FIELDS[record_type].items():
                 raw_value = record["custom_fields"].get(field)
 
                 if not raw_value:
                     continue
 
-                linked_record_ids = raw_value if isinstance(raw_value, list) else [raw_value]
+                linked_record_ids = (
+                    raw_value if isinstance(raw_value, list) else [raw_value]
+                )
 
                 field_values = []
 
                 for linked_record_id in linked_record_ids:
-
                     display_value = linked_record_id
 
                     try:
@@ -90,33 +88,40 @@ class MexRecord(MethodView):
                             if display_value:
                                 break
                     else:
-                        display_value = f'Record with id {linked_record_id} not found'
+                        display_value = f"Record with id {linked_record_id} not found"
 
-                    field_values.append({
-                        "display_value": display_value,
-                        "link_id": linked_record_id
-                    })
+                    field_values.append(
+                        {"display_value": display_value, "link_id": linked_record_id}
+                    )
 
                 linked_records_data[field] = field_values
 
                 field_values = []
 
-                for field, title_field in settings.RECORDS_LINKED_BACKWARDS[record_type].items():
+                for field, title_field in settings.RECORDS_LINKED_BACKWARDS[
+                    record_type
+                ].items():
                     records = _get_record_by_field(field, mex_id)
                     if records:
                         for r in records:
-                            field_values.append({
-                                "link_id": r["custom_fields"]["mex:identifier"],
-                                "display_value": r["custom_fields"].get(title_field, None)
-                            })
+                            field_values.append(
+                                {
+                                    "link_id": r["custom_fields"]["mex:identifier"],
+                                    "display_value": r["custom_fields"].get(
+                                        title_field, None
+                                    ),
+                                }
+                            )
 
                         backwards_linked_records[field] = field_values
 
-        return render_template(self.template,
-                               record=json.loads(record_ui),
-                               linked_records_data=linked_records_data,
-                               backwards_linked_records=backwards_linked_records,
-                               is_preview=False)
+        return render_template(
+            self.template,
+            record=json.loads(record_ui),
+            linked_records_data=linked_records_data,
+            backwards_linked_records=backwards_linked_records,
+            is_preview=False,
+        )
 
     # invenio id: wbdv5-sac84
     # mex id: cP1OvUS7rELcPULquIu1dZ

--- a/site/mex_invenio/scripts/import_data.py
+++ b/site/mex_invenio/scripts/import_data.py
@@ -42,38 +42,52 @@ file_handler.setFormatter(formatter)
 logger.addHandler(file_handler)
 
 
-def process_record(mex_id: str, mex_data: dict, owner_id: int) -> Union[None, dict[str, Any]]:
+def process_record(
+    mex_id: str, mex_data: dict, owner_id: int
+) -> Union[None, dict[str, Any]]:
     """Create and publish a single record."""
     app = current_app._get_current_object()  # Get the actual Flask app object
     with app.app_context():  # Manually push application context in each process
         identity = get_authenticated_identity(owner_id)
 
         try:  # Create draft record and publish
-            search_query = f'custom_fields.mex\:identifier:{mex_id}'
+            search_query = f"custom_fields.mex\:identifier:{mex_id}"
             results = list(current_rdm_records_service.search(identity, q=search_query))
 
             if len(results) == 0:
                 # Create a new record
-                draft = current_rdm_records_service.create(data=mex_data, identity=identity)
-                published = current_rdm_records_service.publish(id_=draft.id, identity=identity)
+                draft = current_rdm_records_service.create(
+                    data=mex_data, identity=identity
+                )
+                published = current_rdm_records_service.publish(
+                    id_=draft.id, identity=identity
+                )
 
-                return {'action': 'create', 'id': published.id}
+                return {"action": "create", "id": published.id}
             elif len(results) == 1:
                 # Update an existing record
-                record_pid = results[0]['id']
+                record_pid = results[0]["id"]
 
                 # Check if the record needs to be updated, it's sufficient to compare
                 # the custom_fields as the Datacite metadata is not expected to change
-                metadata_diff = compare_dicts(results[0]['custom_fields'], mex_data['custom_fields'])
+                metadata_diff = compare_dicts(
+                    results[0]["custom_fields"], mex_data["custom_fields"]
+                )
 
                 if metadata_diff != {}:
-                    new_version = current_rdm_records_service.new_version(id_=record_pid, identity=identity)
-                    current_rdm_records_service.update_draft(identity, new_version.id, mex_data)
-                    new_record = current_rdm_records_service.publish(identity=identity, id_=new_version.id)
+                    new_version = current_rdm_records_service.new_version(
+                        id_=record_pid, identity=identity
+                    )
+                    current_rdm_records_service.update_draft(
+                        identity, new_version.id, mex_data
+                    )
+                    new_record = current_rdm_records_service.publish(
+                        identity=identity, id_=new_version.id
+                    )
 
-                    return {'action': 'update', 'id': new_record.id}
+                    return {"action": "update", "id": new_record.id}
                 else:
-                    return {'action': 'skip', 'id': record_pid}
+                    return {"action": "skip", "id": record_pid}
             elif len(results) > 1:
                 # Log and skip the record if multiple records are found
                 logger.error(f"Multiple records found for MEx id: {mex_id}")
@@ -89,11 +103,13 @@ def _import_data(email: str, filepath: str, batch_size: int):
     return import_data(email, filepath, batch_size, cli=True)
 
 
-def import_data(email: str, filepath: str, batch_size: int = 10 * 1024 * 1024, cli: bool = False) -> bool:
+def import_data(
+    email: str, filepath: str, batch_size: int = 10 * 1024 * 1024, cli: bool = False
+) -> bool:
     """Main function to import data.
-       Batch size is set to 10mb by default.
-       Expected data source is a JSON file with one MEx record per line.
-       About 50k records, or ~100mb."""
+    Batch size is set to 10mb by default.
+    Expected data source is a JSON file with one MEx record per line.
+    About 50k records, or ~100mb."""
 
     if not os.path.isfile(filepath):
         message = f"File {filepath} not found."
@@ -125,7 +141,7 @@ def import_data(email: str, filepath: str, batch_size: int = 10 * 1024 * 1024, c
     # Start the timer to measure processing time
     start_time = time.time()
     num_lines = 0
-    report = {'created': [], 'updated': [], 'skipped': []}
+    report = {"created": [], "updated": [], "skipped": []}
 
     # Batch read the file to avoid memory issues
     with open(filepath) as f:
@@ -134,7 +150,7 @@ def import_data(email: str, filepath: str, batch_size: int = 10 * 1024 * 1024, c
             lines = f.readlines(batch_size)
             num_lines += len(lines)
 
-            if not lines or lines[0] == '':
+            if not lines or lines[0] == "":
                 break
 
             # Use multiprocessing Pool to parallelize the process
@@ -142,7 +158,7 @@ def import_data(email: str, filepath: str, batch_size: int = 10 * 1024 * 1024, c
                 for line in lines:
                     json_data = json.loads(line)
                     clean_data = clean_dict(json_data)
-                    mex_id = json_data['identifier']
+                    mex_id = json_data["identifier"]
 
                     try:
                         mex_data = mex_to_invenio_schema(clean_data)
@@ -155,7 +171,9 @@ def import_data(email: str, filepath: str, batch_size: int = 10 * 1024 * 1024, c
                         logger.error(f"KeyError: {ke}\nError processing record: {line}")
                         continue
 
-                    futures.append(pool.apply_async(process_record, (mex_id, mex_data, owner.id)))
+                    futures.append(
+                        pool.apply_async(process_record, (mex_id, mex_data, owner.id))
+                    )
 
                 # Collect the results as they complete
                 for future in futures:
@@ -163,12 +181,12 @@ def import_data(email: str, filepath: str, batch_size: int = 10 * 1024 * 1024, c
                         result = future.get()  # get the result from the process
 
                         if result is not None:
-                            if result['action'] == 'create':
-                                report['created'].append(result['id'])
-                            elif result['action'] == 'update':
-                                report['updated'].append(result['id'])
-                            elif result['action'] == 'skip':
-                                report['skipped'].append(result['id'])
+                            if result["action"] == "create":
+                                report["created"].append(result["id"])
+                            elif result["action"] == "update":
+                                report["updated"].append(result["id"])
+                            elif result["action"] == "skip":
+                                report["skipped"].append(result["id"])
                     except Exception as e:
                         logger.error(f"Error processing record: {str(e)}")
 
@@ -183,10 +201,14 @@ def import_data(email: str, filepath: str, batch_size: int = 10 * 1024 * 1024, c
         record_count = len(report[action])
 
         if record_count > 0:
-            logger.info(f"{action.capitalize()} {record_count} records. Ids: {report[action]}")
+            logger.info(
+                f"{action.capitalize()} {record_count} records. Ids: {report[action]}"
+            )
 
     if minutes:
-        time_taken = f"Total time taken: {int(minutes)} minutes and {seconds:.2f} seconds."
+        time_taken = (
+            f"Total time taken: {int(minutes)} minutes and {seconds:.2f} seconds."
+        )
     else:
         time_taken = f"Total time taken: {seconds:.2f} seconds."
 

--- a/site/mex_invenio/scripts/utils.py
+++ b/site/mex_invenio/scripts/utils.py
@@ -1,4 +1,5 @@
-""" Utility functions for the MEx-Invenio data import and handling. """
+"""Utility functions for the MEx-Invenio data import and handling."""
+
 import filecmp
 import os
 from datetime import datetime
@@ -15,25 +16,27 @@ def _get_value_by_lang(mex_data: dict, key: str, lang: str) -> str:
     if isinstance(mex_data[key][0], str):
         return mex_data[key][0]
 
-    if [t for t in mex_data[key] if 'language' in t and t['language'] == lang]:
-        return [t for t in mex_data[key] if 'language' in t and t['language'] == lang][0]['value']
+    if [t for t in mex_data[key] if "language" in t and t["language"] == lang]:
+        return [t for t in mex_data[key] if "language" in t and t["language"] == lang][
+            0
+        ]["value"]
 
-    return mex_data[key][0]['value']
+    return mex_data[key][0]["value"]
 
 
 def get_title(mex_data: dict) -> str:
     """Get the title of the record from the MEx metadata."""
-    for key in current_app.config.get('RECORD_METADATA_TITLE_PROPERTIES', ''):
+    for key in current_app.config.get("RECORD_METADATA_TITLE_PROPERTIES", ""):
         if key in mex_data and len(mex_data[key]) > 0:
-            return _get_value_by_lang(mex_data, key, 'de')
+            return _get_value_by_lang(mex_data, key, "de")
 
-    return current_app.config.get('RECORD_METADATA_DEFAULT_TITLE', '')
+    return current_app.config.get("RECORD_METADATA_DEFAULT_TITLE", "")
 
 
 def mex_to_invenio_schema(mex_data: dict) -> dict:
     """Convert MEx schema metadata to internal Invenio RDM Record schema."""
     # Remove the 'Merged' prefix from the entityType in order to be able to process test data
-    resource_type = mex_data.pop("entityType").removeprefix('Merged').lower()
+    resource_type = mex_data.pop("entityType").removeprefix("Merged").lower()
 
     data = {
         "access": {
@@ -46,15 +49,15 @@ def mex_to_invenio_schema(mex_data: dict) -> dict:
         "pids": {},
         "metadata": {
             "resource_type": {"id": resource_type},
-            "creators": [current_app.config.get('RECORD_METADATA_CREATOR', '')],
-            "publication_date": datetime.today().strftime('%Y-%m-%d'),
+            "creators": [current_app.config.get("RECORD_METADATA_CREATOR", "")],
+            "publication_date": datetime.today().strftime("%Y-%m-%d"),
             "title": get_title(mex_data),
         },
-        "custom_fields": {}
+        "custom_fields": {},
     }
 
     for k in mex_data:
-        data['custom_fields'][f'mex:{k}'] = mex_data[k]
+        data["custom_fields"][f"mex:{k}"] = mex_data[k]
 
     return data
 
@@ -66,14 +69,14 @@ def compare_dicts(dict1: dict, dict2: dict) -> dict:
     # Check for keys in dict1 that are not in dict2
     for key in dict1:
         if key not in dict2:
-            diff[key] = {'dict1': dict1[key], 'dict2': None}
+            diff[key] = {"dict1": dict1[key], "dict2": None}
         elif dict1[key] != dict2[key]:
-            diff[key] = {'dict1': dict1[key], 'dict2': dict2[key]}
+            diff[key] = {"dict1": dict1[key], "dict2": dict2[key]}
 
     # Check for keys in dict2 that are not in dict1
     for key in dict2:
         if key not in dict1:
-            diff[key] = {'dict1': None, 'dict2': dict2[key]}
+            diff[key] = {"dict1": None, "dict2": dict2[key]}
 
     return diff
 
@@ -90,7 +93,9 @@ def clean_dict(d: dict) -> Union[dict[Any, dict], list[dict], dict]:
 
 def compare_files(existing_file: str, new_file: str) -> bool:
     """Compares files and deletes the new file if it's the same."""
-    if os.path.exists(existing_file) and filecmp.cmp(existing_file, new_file, shallow=False):
+    if os.path.exists(existing_file) and filecmp.cmp(
+        existing_file, new_file, shallow=False
+    ):
         os.remove(new_file)  # Remove duplicate file
         return True
     return False

--- a/site/mex_invenio/views.py
+++ b/site/mex_invenio/views.py
@@ -40,7 +40,9 @@ def redirect_to_mex(record_id):
     pid = None
     record = None
 
-    resolver = Resolver(pid_type="recid", object_type="rec", getter=RDMRecord.get_record)
+    resolver = Resolver(
+        pid_type="recid", object_type="rec", getter=RDMRecord.get_record
+    )
 
     try:
         pid, record = resolver.resolve(record_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,18 +12,31 @@ from dotenv import find_dotenv, load_dotenv
 from invenio_access.permissions import system_identity
 from invenio_accounts.models import User
 from invenio_app.factory import create_ui
-from invenio_rdm_records.cli import create_records_custom_field, custom_field_exists_in_records
+from invenio_rdm_records.cli import (
+    create_records_custom_field,
+    custom_field_exists_in_records,
+)
 from invenio_rdm_records.proxies import current_rdm_records
 from invenio_vocabularies.proxies import current_service as vocabulary_service
 from invenio_vocabularies.records.api import Vocabulary
 
 from mex_invenio.scripts.import_data import _import_data
-from mex_invenio.config import (OAISERVER_ID_PREFIX, OAISERVER_RELATIONS, RECORD_METADATA_CREATOR,
-                                RECORD_METADATA_DEFAULT_TITLE, RECORD_METADATA_TITLE_PROPERTIES)
-from mex_invenio.custom_fields.custom_fields import RDM_CUSTOM_FIELDS, RDM_CUSTOM_FIELDS_UI, RDM_NAMESPACES
+from mex_invenio.config import (
+    OAISERVER_ID_PREFIX,
+    OAISERVER_RELATIONS,
+    RECORD_METADATA_CREATOR,
+    RECORD_METADATA_DEFAULT_TITLE,
+    RECORD_METADATA_TITLE_PROPERTIES,
+)
+from mex_invenio.custom_fields.custom_fields import (
+    RDM_CUSTOM_FIELDS,
+    RDM_CUSTOM_FIELDS_UI,
+    RDM_NAMESPACES,
+)
 
 
-created_regex = r'Created (\d) records. Ids: \[\'(\w{5}-\w{5})\'\]'
+created_regex = r"Created (\d) records. Ids: \[\'(\w{5}-\w{5})\'\]"
+
 
 def search_messages(messages, pattern):
     for message in messages:
@@ -31,18 +44,18 @@ def search_messages(messages, pattern):
             return re.search(pattern, message)
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def load_env():
-    env_file = find_dotenv('.env.tests')
+    env_file = find_dotenv(".env.tests")
     load_dotenv(env_file)
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def module_tmp_path(tmp_path_factory):
-    return tmp_path_factory.mktemp('module_temp')
+    return tmp_path_factory.mktemp("module_temp")
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def app_config(app_config, module_tmp_path):
     # sqllite refused to create mock db without those parameters and they are missing
     app_config["SQLALCHEMY_ENGINE_OPTIONS"] = {
@@ -55,25 +68,25 @@ def app_config(app_config, module_tmp_path):
     app_config["SERVER_NAME"] = "127.0.0.1"
 
     # add custom fields
-    app_config['RDM_NAMESPACES'] = RDM_NAMESPACES
-    app_config['RDM_CUSTOM_FIELDS'] = RDM_CUSTOM_FIELDS
-    app_config['RDM_CUSTOM_FIELDS_UI'] = RDM_CUSTOM_FIELDS_UI
+    app_config["RDM_NAMESPACES"] = RDM_NAMESPACES
+    app_config["RDM_CUSTOM_FIELDS"] = RDM_CUSTOM_FIELDS
+    app_config["RDM_CUSTOM_FIELDS_UI"] = RDM_CUSTOM_FIELDS_UI
 
     # add import settings
-    app_config['RECORD_METADATA_DEFAULT_TITLE'] = RECORD_METADATA_DEFAULT_TITLE
-    app_config['RECORD_METADATA_TITLE_PROPERTIES'] = RECORD_METADATA_TITLE_PROPERTIES
-    app_config['RECORD_METADATA_CREATOR'] = RECORD_METADATA_CREATOR
+    app_config["RECORD_METADATA_DEFAULT_TITLE"] = RECORD_METADATA_DEFAULT_TITLE
+    app_config["RECORD_METADATA_TITLE_PROPERTIES"] = RECORD_METADATA_TITLE_PROPERTIES
+    app_config["RECORD_METADATA_CREATOR"] = RECORD_METADATA_CREATOR
 
     # add oai
-    app_config['OAISERVER_ID_PREFIX'] = OAISERVER_ID_PREFIX
-    app_config['OAISERVER_RELATIONS'] = OAISERVER_RELATIONS
+    app_config["OAISERVER_ID_PREFIX"] = OAISERVER_ID_PREFIX
+    app_config["OAISERVER_RELATIONS"] = OAISERVER_RELATIONS
 
     # add S3
-    app_config['S3_DOWNLOAD_FOLDER'] = module_tmp_path
+    app_config["S3_DOWNLOAD_FOLDER"] = module_tmp_path
     return app_config
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def create_app():
     return create_ui
 
@@ -93,9 +106,7 @@ def resource_type_v(app, resource_type_type):
         {
             "id": "contactpoint",
             "icon": "code",
-            "props": {
-                "type": "contactpoint"
-            },
+            "props": {"type": "contactpoint"},
             "title": {"en": "Contact point"},
             "tags": ["depositable", "linkable"],
             "type": "resourcetypes",
@@ -107,9 +118,7 @@ def resource_type_v(app, resource_type_type):
         {
             "id": "organizationalunit",
             "icon": "code",
-            "props": {
-                "type": "organizationalunit"
-            },
+            "props": {"type": "organizationalunit"},
             "title": {"en": "Organizational unit"},
             "tags": ["depositable", "linkable"],
             "type": "resourcetypes",
@@ -121,16 +130,14 @@ def resource_type_v(app, resource_type_type):
         {
             "id": "resource",
             "icon": "code",
-            "props": {
-                "type": "resource"
-            },
+            "props": {"type": "resource"},
             "title": {"en": "Resource"},
             "tags": ["depositable", "linkable"],
             "type": "resourcetypes",
         },
     )
 
-    '''vocab = vocabulary_service.create(
+    """vocab = vocabulary_service.create(
         system_identity,
         {
             "id": "image-photo",
@@ -152,7 +159,7 @@ def resource_type_v(app, resource_type_type):
             "tags": ["depositable", "linkable"],
             "type": "resourcetypes",
         },
-    )'''
+    )"""
 
     Vocabulary.index.refresh()
 
@@ -178,7 +185,7 @@ def contributors_role_v(app, contributors_role_type):
         },
     )
 
-    '''vocabulary_service.create(
+    """vocabulary_service.create(
         system_identity,
         {
             "id": "projectmanager",
@@ -196,7 +203,7 @@ def contributors_role_v(app, contributors_role_type):
             "title": {"en": "Other"},
             "type": "contributorsroles",
         },
-    )'''
+    )"""
 
     Vocabulary.index.refresh()
 
@@ -232,13 +239,14 @@ def initialise_custom_fields(app, location, db, search_clear, cli_runner):
 @pytest.fixture
 def create_file(tmp_path):
     """Create a file, either absolute or relative to the tmp_path."""
+
     def _create_file(filename, data, absolute=False):
         if isinstance(data, dict):
             data = json.dumps(data)
 
         if absolute:
-            os.makedirs("/".join(filename.split('/')[-1]), exist_ok=True)
-            with open(filename, 'w') as f:
+            os.makedirs("/".join(filename.split("/")[-1]), exist_ok=True)
+            with open(filename, "w") as f:
                 f.write(data)
             file_path = filename
         else:
@@ -262,12 +270,20 @@ def create_user(db):
 
 
 @pytest.fixture
-def import_file(initialise_custom_fields, custom_field_exists, db, caplog, cli_runner, create_user, create_file):
-    email = 'importer@address.com'
-    create_user('importer', email)
+def import_file(
+    initialise_custom_fields,
+    custom_field_exists,
+    db,
+    caplog,
+    cli_runner,
+    create_user,
+    create_file,
+):
+    email = "importer@address.com"
+    create_user("importer", email)
 
     def _import_file(filename, data):
-        contact_point_file = create_file(f'{filename}.json', data)
+        contact_point_file = create_file(f"{filename}.json", data)
 
         with caplog.at_level(logging.INFO):
             cli_runner(_import_data, email, contact_point_file)

--- a/tests/data.py
+++ b/tests/data.py
@@ -1,89 +1,136 @@
-contact_point_data = {"email": ["reginagarrett@example.com"],
-                      "entityType": "MergedContactPoint",
-                      "identifier": "zJBx8K7g9mQ8X03VZHnxW"}
+contact_point_data = {
+    "email": ["reginagarrett@example.com"],
+    "entityType": "MergedContactPoint",
+    "identifier": "zJBx8K7g9mQ8X03VZHnxW",
+}
 
-org_unit_data = {"parentUnit": "Y7DWGmva2fT9KRFMaMTFU",
-                 "name": [{
-                     "value": "Class on reach. Yourself affect station member.",
-                     "language": "en"}, {
-                     "value": "Require agree inside thank. Item bit leave left college listen.",
-                     "language": "en"}],
-                 "alternativeName": [{
-                     "value": "Get car party close issue. Less politics religious back international risk.",
-                     "language": "en"}],
-                 "email": ["jimmy65@example.com", "ahunt@example.com"],
-                 "website": [{"language": '', "title": 'Atkins', "url": "http://www.atkins.org/"}],
-                 "shortName": [
-                     {"value": "Other relate very military recent positive daughter popular.", "language": "en"}],
-                 "unitOf": ["gZBuFwpt6xbsvc4dCFWAUs", "f4uuJm2zYNFz1aY8qbgwg"],
-                 "entityType": "MergedOrganizationalUnit",
-                 "identifier": "sLrfLJKbfnSUGkMJsOXA5"}
+org_unit_data = {
+    "parentUnit": "Y7DWGmva2fT9KRFMaMTFU",
+    "name": [
+        {"value": "Class on reach. Yourself affect station member.", "language": "en"},
+        {
+            "value": "Require agree inside thank. Item bit leave left college listen.",
+            "language": "en",
+        },
+    ],
+    "alternativeName": [
+        {
+            "value": "Get car party close issue. Less politics religious back international risk.",
+            "language": "en",
+        }
+    ],
+    "email": ["jimmy65@example.com", "ahunt@example.com"],
+    "website": [{"language": "", "title": "Atkins", "url": "http://www.atkins.org/"}],
+    "shortName": [
+        {
+            "value": "Other relate very military recent positive daughter popular.",
+            "language": "en",
+        }
+    ],
+    "unitOf": ["gZBuFwpt6xbsvc4dCFWAUs", "f4uuJm2zYNFz1aY8qbgwg"],
+    "entityType": "MergedOrganizationalUnit",
+    "identifier": "sLrfLJKbfnSUGkMJsOXA5",
+}
 
-resource_data = {"accessRestriction": "https://mex.rki.de/item/access-restriction-1",
-                 "accrualPeriodicity": "https://mex.rki.de/item/frequency-14",
-                 "created": "2008-11-08",
-                 "doi": None,
-                 "hasPersonalData": "https://mex.rki.de/item/personal-data-1",
-                 "license": "https://mex.rki.de/item/license-1",
-                 "maxTypicalAge": 5001,
-                 "minTypicalAge": 529,
-                 "modified": "2021-03",
-                 "sizeOfDataBasis": None,
-                 "temporal": None,
-                 "wasGeneratedBy": "hLnv7W2yAcM8CJZE5AMBof",
-                 "contact": ["buz8FH8lnXEHVVMKqR1sWz"],
-                 "theme": ["https://mex.rki.de/item/theme-22"],
-                 "title": [{"value": "Ding nein drehen.", "language": "de"}],
-                 "unitInCharge": ["sLrfLJKbfnSUGkMJsOXA5", "yAflS4smRTINBczZqqkrU"],
-                 "accessPlatform": [],
-                 "alternativeTitle": [],
-                 "anonymizationPseudonymization": ["https://mex.rki.de/item/anonymization-pseudonymization-2"],
-                 "conformsTo": ["voll kennen \u00fcber"],
-                 "contributingUnit": [],
-                 "contributor": ["gwjehcvTCGBH4CTyDWTiXY", "ddTKOu0dKtmUsy6SoGjxBC"],
-                 "creator": [],
-                 "description": [{
-                     "value": "Monate m\u00f6glich hin geh\u00f6ren Mutter Blume.",
-                     "language": "de"}],
-                 "distribution": ["fLlm4wEn768NK6Bixsfk43"],
-                 "documentation": [{"language": None, "title": None, "url": "http://weinhage.com/"},
-                                   {"language": "en", "title": "Lindau", "url": "http://www.koch.com/"}],
-                 "externalPartner": [],
-                 "hasLegalBasis": [{"value": "Antworten nie gibt.", "language": "de"}],
-                 "icd10code": [],
-                 "instrumentToolOrApparatus": [{
-                     "value": "Nehmen Wort w\u00fcnschen gro\u00df damit Stein immer. Langsam Weg See selbst.",
-                     "language": "de"}],
-                 "isPartOf": ["dO8iP5KEwJGZPXwCXKnFOZ"],
-                 "keyword": [{
-                     "value": "Halbe gelb beim braun stehen Kind das Wiese. Unter viel Zug laut wohnen Flasche.",
-                     "language": "de"}],
-                 "language": [],
-                 "loincId": [],
-                 "meshId": ["http://id.nlm.nih.gov/mesh/D000020", "http://id.nlm.nih.gov/mesh/D000024"],
-                 "method": [{
-                     "value": "Blume verstecken wirklich jeder Leben. Denn Teller Sommer oft Eis bei\u00dfen.",
-                     "language": "de"}],
-                 "methodDescription": [{
-                     "value": "Schwester waschen Wasser Bruder. Sieben hin lassen den den werden.",
-                     "language": "de"}],
-                 "populationCoverage": [],
-                 "publication": [],
-                 "publisher": [],
-                 "qualityInformation": [{
-                     "value": "Sitzen dann davon fertig merken richtig.",
-                     "language": "de"}],
-                 "resourceCreationMethod": [],
-                 "resourceTypeGeneral": ["https://mex.rki.de/item/resource-type-general-18",
-                                         "https://mex.rki.de/item/resource-type-general-13",
-                                         "https://mex.rki.de/item/resource-type-general-2"],
-                 "resourceTypeSpecific": [],
-                 "rights": [],
-                 "spatial": [{"value": "Sohn Seite waschen. Wohnen zur\u00fcck Woche ob zur Wasser.", "language": "de"},
-                             {
-                                 "value": "Nennen fallen acht. Sich ihr sprechen beide Opa wieder was.",
-                                 "language": "de"}],
-                 "stateOfDataProcessing": ["https://mex.rki.de/item/data-processing-state-1",
-                                           "https://mex.rki.de/item/data-processing-state-2"],
-                 "entityType": "MergedResource",
-                 "identifier": "fGh6zMaW4iugHnDnw17601"}
+resource_data = {
+    "accessRestriction": "https://mex.rki.de/item/access-restriction-1",
+    "accrualPeriodicity": "https://mex.rki.de/item/frequency-14",
+    "created": "2008-11-08",
+    "doi": None,
+    "hasPersonalData": "https://mex.rki.de/item/personal-data-1",
+    "license": "https://mex.rki.de/item/license-1",
+    "maxTypicalAge": 5001,
+    "minTypicalAge": 529,
+    "modified": "2021-03",
+    "sizeOfDataBasis": None,
+    "temporal": None,
+    "wasGeneratedBy": "hLnv7W2yAcM8CJZE5AMBof",
+    "contact": ["buz8FH8lnXEHVVMKqR1sWz"],
+    "theme": ["https://mex.rki.de/item/theme-22"],
+    "title": [{"value": "Ding nein drehen.", "language": "de"}],
+    "unitInCharge": ["sLrfLJKbfnSUGkMJsOXA5", "yAflS4smRTINBczZqqkrU"],
+    "accessPlatform": [],
+    "alternativeTitle": [],
+    "anonymizationPseudonymization": [
+        "https://mex.rki.de/item/anonymization-pseudonymization-2"
+    ],
+    "conformsTo": ["voll kennen \u00fcber"],
+    "contributingUnit": [],
+    "contributor": ["gwjehcvTCGBH4CTyDWTiXY", "ddTKOu0dKtmUsy6SoGjxBC"],
+    "creator": [],
+    "description": [
+        {
+            "value": "Monate m\u00f6glich hin geh\u00f6ren Mutter Blume.",
+            "language": "de",
+        }
+    ],
+    "distribution": ["fLlm4wEn768NK6Bixsfk43"],
+    "documentation": [
+        {"language": None, "title": None, "url": "http://weinhage.com/"},
+        {"language": "en", "title": "Lindau", "url": "http://www.koch.com/"},
+    ],
+    "externalPartner": [],
+    "hasLegalBasis": [{"value": "Antworten nie gibt.", "language": "de"}],
+    "icd10code": [],
+    "instrumentToolOrApparatus": [
+        {
+            "value": "Nehmen Wort w\u00fcnschen gro\u00df damit Stein immer. Langsam Weg See selbst.",
+            "language": "de",
+        }
+    ],
+    "isPartOf": ["dO8iP5KEwJGZPXwCXKnFOZ"],
+    "keyword": [
+        {
+            "value": "Halbe gelb beim braun stehen Kind das Wiese. Unter viel Zug laut wohnen Flasche.",
+            "language": "de",
+        }
+    ],
+    "language": [],
+    "loincId": [],
+    "meshId": [
+        "http://id.nlm.nih.gov/mesh/D000020",
+        "http://id.nlm.nih.gov/mesh/D000024",
+    ],
+    "method": [
+        {
+            "value": "Blume verstecken wirklich jeder Leben. Denn Teller Sommer oft Eis bei\u00dfen.",
+            "language": "de",
+        }
+    ],
+    "methodDescription": [
+        {
+            "value": "Schwester waschen Wasser Bruder. Sieben hin lassen den den werden.",
+            "language": "de",
+        }
+    ],
+    "populationCoverage": [],
+    "publication": [],
+    "publisher": [],
+    "qualityInformation": [
+        {"value": "Sitzen dann davon fertig merken richtig.", "language": "de"}
+    ],
+    "resourceCreationMethod": [],
+    "resourceTypeGeneral": [
+        "https://mex.rki.de/item/resource-type-general-18",
+        "https://mex.rki.de/item/resource-type-general-13",
+        "https://mex.rki.de/item/resource-type-general-2",
+    ],
+    "resourceTypeSpecific": [],
+    "rights": [],
+    "spatial": [
+        {
+            "value": "Sohn Seite waschen. Wohnen zur\u00fcck Woche ob zur Wasser.",
+            "language": "de",
+        },
+        {
+            "value": "Nennen fallen acht. Sich ihr sprechen beide Opa wieder was.",
+            "language": "de",
+        },
+    ],
+    "stateOfDataProcessing": [
+        "https://mex.rki.de/item/data-processing-state-1",
+        "https://mex.rki.de/item/data-processing-state-2",
+    ],
+    "entityType": "MergedResource",
+    "identifier": "fGh6zMaW4iugHnDnw17601",
+}

--- a/tests/test_custom_fields.py
+++ b/tests/test_custom_fields.py
@@ -4,27 +4,32 @@ from invenio_rdm_records.proxies import current_rdm_records
 from tests.data import org_unit_data
 
 
-def test_import_org_unit(db, location, resource_type_v, contributors_role_v, import_file):
+def test_import_org_unit(
+    db, location, resource_type_v, contributors_role_v, import_file
+):
     """Test that the CLI command imports the org unit data correctly"""
     service = current_rdm_records.records_service
 
-    messages = import_file('org-unit', org_unit_data)
+    messages = import_file("org-unit", org_unit_data)
 
     search_obj = service.search(system_identity)
     record = list(search_obj.hits)[0]
 
-    rec_cf = record['custom_fields']
+    rec_cf = record["custom_fields"]
 
-    assert record['metadata']['title'] == org_unit_data['name'][0]['value']
+    assert record["metadata"]["title"] == org_unit_data["name"][0]["value"]
     assert rec_cf is not {}
-    assert rec_cf['mex:identifier'] == org_unit_data['identifier']
-    assert rec_cf['mex:shortName'][0]['value'] == org_unit_data['shortName'][0]['value']
-    assert org_unit_data['unitOf'] == rec_cf['mex:unitOf']
+    assert rec_cf["mex:identifier"] == org_unit_data["identifier"]
+    assert rec_cf["mex:shortName"][0]["value"] == org_unit_data["shortName"][0]["value"]
+    assert org_unit_data["unitOf"] == rec_cf["mex:unitOf"]
 
     # test for the custom field link
-    assert len(rec_cf['mex:website']) == 1
-    assert rec_cf['mex:website'][0]['url'] == org_unit_data['website'][0]['url']
+    assert len(rec_cf["mex:website"]) == 1
+    assert rec_cf["mex:website"][0]["url"] == org_unit_data["website"][0]["url"]
 
     # test for the custom field multi-language text
-    assert len(rec_cf['mex:alternativeName']) == 1
-    assert rec_cf['mex:alternativeName'][0]['value'] == org_unit_data['alternativeName'][0]['value']
+    assert len(rec_cf["mex:alternativeName"]) == 1
+    assert (
+        rec_cf["mex:alternativeName"][0]["value"]
+        == org_unit_data["alternativeName"][0]["value"]
+    )

--- a/tests/test_import_data.py
+++ b/tests/test_import_data.py
@@ -11,45 +11,46 @@ from tests.data import contact_point_data
 
 def test_nonexistent_file_error_cli(cli_runner, db):
     """Test that the CLI command exits with an error when the file does not exist."""
-    email = 'alice@address.com'
-    filepath = 'path/to/file'
-    db.session.add(User(username='alice', email=email))
+    email = "alice@address.com"
+    filepath = "path/to/file"
+    db.session.add(User(username="alice", email=email))
     db.session.commit()
 
     result = cli_runner(_import_data, email, filepath)
 
     assert result.exit_code == 1
-    assert f'File {filepath} not found.' in result.output
+    assert f"File {filepath} not found." in result.output
     assert User.query.count() == 1
 
 
 def test_nonexistent_user_error_cli(cli_runner, db, create_file):
     """Test that the CLI command exits with an error when the user does not exist."""
-    email = 'non-existent-user@address.com'
-    result = cli_runner(_import_data, email, create_file('empty.json', '{}'))
+    email = "non-existent-user@address.com"
+    result = cli_runner(_import_data, email, create_file("empty.json", "{}"))
 
     assert result.exit_code == 1
-    assert f'User with email {email} not found.' in result.output
+    assert f"User with email {email} not found." in result.output
 
 
 def test_import_corrupt_data_cli(cli_runner, db, create_file):
     """Test that the CLI command logs an error when the data is corrupt."""
-    email = 'importer@address.com'
-    db.session.add(User(username='importer', email=email))
+    email = "importer@address.com"
+    db.session.add(User(username="importer", email=email))
     db.session.commit()
 
-    result = cli_runner(_import_data, email, create_file('corrupt.json', '{'))
+    result = cli_runner(_import_data, email, create_file("corrupt.json", "{"))
 
     assert result.exit_code == 1
     assert isinstance(result.exception, JSONDecodeError)
 
 
-def test_import_contact_point(db, location, resource_type_v, contributors_role_v,
-                              import_file):
+def test_import_contact_point(
+    db, location, resource_type_v, contributors_role_v, import_file
+):
     """Test that the CLI command imports the contact point data correctly."""
     service = current_rdm_records.records_service
 
-    messages = import_file('contact-point', contact_point_data)
+    messages = import_file("contact-point", contact_point_data)
 
     # Log output is captured in the import_file fixture defined in
     # conftest and returned by the fixture as a list of messages.
@@ -65,4 +66,4 @@ def test_import_contact_point(db, location, resource_type_v, contributors_role_v
     record = list(search_obj.hits)[0]
 
     assert search_obj.total == number_of_records_published
-    assert record['id'] == published_record_id
+    assert record["id"] == published_record_id

--- a/tests/test_oai.py
+++ b/tests/test_oai.py
@@ -7,22 +7,24 @@ from tests.data import resource_data
 def test_oai_mex_format_exists(app, client):
     """Test that the OAI-PMH Mex crosswalk exists."""
 
-    res = client.get('/oai2d?verb=ListMetadataFormats')
+    res = client.get("/oai2d?verb=ListMetadataFormats")
 
     tree = ET.ElementTree(ET.fromstring(res.data))
     root = tree.getroot()
 
-    oai_url = '{http://www.openarchives.org/OAI/2.0/}'
+    oai_url = "{http://www.openarchives.org/OAI/2.0/}"
     oai_dc = root.find(f'.//{oai_url}metadataFormat[{oai_url}metadataPrefix="oai_dc"]')
 
     assert res.status_code == 200
     assert oai_dc is not None
 
 
-def test_get_oai_record(client, db, location, resource_type_v, contributors_role_v, import_file, app_config):
+def test_get_oai_record(
+    client, db, location, resource_type_v, contributors_role_v, import_file, app_config
+):
     """Test that the OAI-PMH ListRecords verb returns the correct record."""
-    oai_prefix = app_config['OAISERVER_ID_PREFIX']
-    messages = import_file('resource', resource_data)
+    oai_prefix = app_config["OAISERVER_ID_PREFIX"]
+    messages = import_file("resource", resource_data)
 
     match = search_messages(messages, created_regex)
 
@@ -30,36 +32,36 @@ def test_get_oai_record(client, db, location, resource_type_v, contributors_role
     rec_id = match.group(2)
     # oai_url = f"/oai2d?verb=GetRecord&identifier=oai:{oai_prefix}:{rec_id}&metadataPrefix=oai_mex"
 
-    res = client.get('/oai2d?verb=ListRecords&metadataPrefix=oai_dc')
+    res = client.get("/oai2d?verb=ListRecords&metadataPrefix=oai_dc")
     assert res.status_code == 200
 
     tree = ET.ElementTree(ET.fromstring(res.data))
     root = tree.getroot()
 
     # Define namespaces
-    oai_namespace = {'oai': 'http://www.openarchives.org/OAI/2.0/'}
-    dc_namespace = {'dc': 'http://purl.org/dc/elements/1.1/'}
+    oai_namespace = {"oai": "http://www.openarchives.org/OAI/2.0/"}
+    dc_namespace = {"dc": "http://purl.org/dc/elements/1.1/"}
 
     # Find the ListRecords element
-    list_records = root.find('oai:ListRecords', oai_namespace)
+    list_records = root.find("oai:ListRecords", oai_namespace)
     assert len(list_records) == 1
 
     for rec in list_records:
-        metadata = rec.find('oai:metadata', oai_namespace)
-        ids = [_id.text for _id in metadata.findall('.//dc:identifier', dc_namespace)]
+        metadata = rec.find("oai:metadata", oai_namespace)
+        ids = [_id.text for _id in metadata.findall(".//dc:identifier", dc_namespace)]
         assert len(ids) == 2
-        assert f'oai:{oai_prefix}:{rec_id}' in ids
-        assert resource_data['identifier'] in ids
+        assert f"oai:{oai_prefix}:{rec_id}" in ids
+        assert resource_data["identifier"] in ids
 
-        description = metadata.find('.//dc:description', dc_namespace)
-        assert description.text == resource_data['description'][0]['value']
-        rec_license = metadata.find('.//dc:rights', dc_namespace)
-        assert rec_license.text == 'info:eu-repo/semantics/openAccess'
+        description = metadata.find(".//dc:description", dc_namespace)
+        assert description.text == resource_data["description"][0]["value"]
+        rec_license = metadata.find(".//dc:rights", dc_namespace)
+        assert rec_license.text == "info:eu-repo/semantics/openAccess"
 
-        if 'mex:unitInCharge' in app_config['OAISERVER_RELATIONS']:
-            unit_in_charge = metadata.find('.//dc:relation', dc_namespace)
-            assert unit_in_charge.text in resource_data['unitInCharge']
+        if "mex:unitInCharge" in app_config["OAISERVER_RELATIONS"]:
+            unit_in_charge = metadata.find(".//dc:relation", dc_namespace)
+            assert unit_in_charge.text in resource_data["unitInCharge"]
 
         # there will be 2 dates, created by invenio and mex:created
-        dates = metadata.findall('.//dc:date', dc_namespace)
-        assert resource_data['created'] in [date.text for date in dates]
+        dates = metadata.findall(".//dc:date", dc_namespace)
+        assert resource_data["created"] in [date.text for date in dates]

--- a/tests/test_s3_manager.py
+++ b/tests/test_s3_manager.py
@@ -5,22 +5,27 @@ from mex_invenio.scripts.s3_manager import manage_s3_files, get_latest_file
 
 from freezegun import freeze_time
 
-def test_identical_files(app_config, db, create_file, load_env, mock_s3_client, cli_runner):
+
+def test_identical_files(
+    app_config, db, create_file, load_env, mock_s3_client, cli_runner
+):
     # download_path is a module scope temp path, so we need to be careful about
     # file names
-    download_path = app_config['S3_DOWNLOAD_FOLDER']
+    download_path = app_config["S3_DOWNLOAD_FOLDER"]
 
     # Create the existing file in the S3_DOWNLOAD_FOLDER
-    existing_file = 'test_identical_files_1.json'
-    existing_file_path = create_file(f'{download_path}/{existing_file}', '{}', absolute=True)
+    existing_file = "test_identical_files_1.json"
+    existing_file_path = create_file(
+        f"{download_path}/{existing_file}", "{}", absolute=True
+    )
 
     # Establish the file path of the file to be downloaded from S3
-    downloaded_file = 'test_identical_files_2.json'
-    downloaded_file_path = f'{download_path}/{downloaded_file}'
+    downloaded_file = "test_identical_files_2.json"
+    downloaded_file_path = f"{download_path}/{downloaded_file}"
 
     # Mock the download_file function to create the file locally
     def download_file(Bucket, Key, Filename):
-        create_file(downloaded_file_path, '{}', absolute=True)
+        create_file(downloaded_file_path, "{}", absolute=True)
 
     mock_s3_client.download_file = download_file
 
@@ -28,47 +33,61 @@ def test_identical_files(app_config, db, create_file, load_env, mock_s3_client, 
     # the single key 'Contents' and each file has more information than just the
     # 'Key' and 'LastModified' keys but this is all we need for unit testing.
     mock_s3_client.list_objects_v2.return_value = {
-        'Contents': [{'Key': downloaded_file_path, 'LastModified': datetime.datetime.now()}]}
+        "Contents": [
+            {"Key": downloaded_file_path, "LastModified": datetime.datetime.now()}
+        ]
+    }
     # {'Key': file_path2, 'LastModified': datetime.datetime.now()}]}
 
     # Import should not import anything and the younger file should be removed
     result = cli_runner(manage_s3_files, "--check")
 
-    assert result.exit_code == 0 # No files imported
+    assert result.exit_code == 0  # No files imported
     assert os.path.exists(existing_file_path)
     assert not os.path.exists(downloaded_file_path)
 
+
 @freeze_time("2023-01-01")
-def test_replace_file_but_fail_import(app_config, db, create_file, load_env, mock_s3_client, cli_runner):
+def test_replace_file_but_fail_import(
+    app_config, db, create_file, load_env, mock_s3_client, cli_runner
+):
     # download_path is a module scope temp path, so we need to be careful about
     # file names
-    download_path = app_config['S3_DOWNLOAD_FOLDER']
+    download_path = app_config["S3_DOWNLOAD_FOLDER"]
 
     # Create the existing file in the S3_DOWNLOAD_FOLDER
-    existing_file = 'test_replace_file_but_fail_import1.json'
-    existing_file_path = create_file(f'{download_path}/{existing_file}', '{"s":"a"}', absolute=True)
+    existing_file = "test_replace_file_but_fail_import1.json"
+    existing_file_path = create_file(
+        f"{download_path}/{existing_file}", '{"s":"a"}', absolute=True
+    )
 
     # Establish the file path of the file to be downloaded from S3
-    downloaded_file = 'test_replace_file_but_fail_import2.json'
-    downloaded_file_path = f'{download_path}/{downloaded_file}'
+    downloaded_file = "test_replace_file_but_fail_import2.json"
+    downloaded_file_path = f"{download_path}/{downloaded_file}"
 
     # Mock the download_file function to create the file locally
     def download_file(Bucket, Key, Filename):
         create_file(downloaded_file_path, '{"s":"b"}', absolute=True)
+
     mock_s3_client.download_file = download_file
 
     # Pretend S3 is returning them, the returned dict has more information than
     # the single key 'Contents' and each file has more information than just the
     # 'Key' and 'LastModified' keys but this is all we need for unit testing.
     mock_s3_client.list_objects_v2.return_value = {
-        'Contents': [{'Key': downloaded_file_path, 'LastModified': datetime.datetime.now()}]}
-    #{'Key': file_path2, 'LastModified': datetime.datetime.now()}]}
+        "Contents": [
+            {"Key": downloaded_file_path, "LastModified": datetime.datetime.now()}
+        ]
+    }
+    # {'Key': file_path2, 'LastModified': datetime.datetime.now()}]}
 
     # Import should not import anything and the younger file should be removed
     result = cli_runner(manage_s3_files, "--check")
 
-    renamed_downloaded_file = f'{download_path}/20230101000000_{downloaded_file}'
+    renamed_downloaded_file = f"{download_path}/20230101000000_{downloaded_file}"
 
     assert not os.path.exists(existing_file_path)
-    assert result.exit_code == 1 # The import job will error because the user is not found
+    assert (
+        result.exit_code == 1
+    )  # The import job will error because the user is not found
     assert os.path.exists(renamed_downloaded_file)


### PR DESCRIPTION
- This PR adds the [ruff formatter](https://pypi.org/project/ruff/) as a pre-commit-hook.
- Ruff implements [isort](https://pypi.org/project/isort/), [black](https://pypi.org/project/black/) and [flake8](https://pypi.org/project/flake8/) formatting rules.
- It will ensure a consistent code format with the other MEx python repositories.