### PR TITLE
Add config to disable dependabot prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
This PR is to disable dependabot from automatically creating [pull requests](https://github.com/robert-koch-institut/mex-invenio/pulls?q=is%3Apr+is%3Aclosed+label%3Adependencies).