### PR TITLE
Add a route to return record as json

### DIFF
--- a/site/mex_invenio/record/record.py
+++ b/site/mex_invenio/record/record.py
@@ -15,7 +15,7 @@ class MexRecord(MethodView):
     def __init__(self):
         self.template = "invenio_app_rdm/records/detail.html"
 
-    def get(self, mex_id):
+    def get(self, mex_id, as_json=False):
         version_id = request.args.get("version_id", None)
 
         # Establish the version_id as an integer if it is provided
@@ -52,6 +52,10 @@ class MexRecord(MethodView):
         record_item = current_rdm_records_service.read(g.identity, pid)
         ui_serializer = UIJSONSerializer()
         record_ui = ui_serializer.serialize_object(record_item.data)
+
+        # Just return the record as JSON if requested
+        if as_json:
+            return json.loads(record_ui)
 
         linked_records_data = _get_linked_records_data(record_item, mex_id)
 

--- a/site/mex_invenio/views.py
+++ b/site/mex_invenio/views.py
@@ -34,6 +34,12 @@ def create_blueprint(app):
         view_func=MexRecord.as_view("mex_view"),
     )
 
+    blueprint.add_url_rule(
+        "/records/mex/<mex_id>/json",
+        view_func=MexRecord.as_view("mex_json_view"),
+        defaults={"as_json": True},
+    )
+
     return blueprint
 
 


### PR DESCRIPTION
This PR adds a an endpoint ` /records/mex/<mex_id>/json`.

Giving the basic functionality requested in #103 

However, this does not introduce a REST API endpoint with browsing, aggregations etc. comparable to `/api/records`.

I'm still researching whether that is possible