### PR TITLE
remove file logging from import and s3 scripts - use redirection instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,6 @@ COPY site ./site
 COPY Pipfile Pipfile.lock ./
 RUN pipenv install --deploy --system
 
-# Logs dir for the import script
-RUN mkdir -p ./logs
-
 COPY ./docker/uwsgi/ ${INVENIO_INSTANCE_PATH}
 COPY ./invenio.cfg ${INVENIO_INSTANCE_PATH}
 COPY ./templates/ ${INVENIO_INSTANCE_PATH}/templates/
@@ -26,8 +23,6 @@ COPY ./ .
 
 # Run the translations
 RUN pybabel compile --directory=${INVENIO_INSTANCE_PATH}/translations
-
-RUN mkdir -p ${INVENIO_INSTANCE_PATH}/logs/
 
 RUN cp -r ./static/. ${INVENIO_INSTANCE_PATH}/static/ && \
     cp -r ./assets/. ${INVENIO_INSTANCE_PATH}/assets/ && \

--- a/logs/.gitkeep
+++ b/logs/.gitkeep
@@ -1,1 +1,0 @@
-# This file exists only to add logs/ folder to git repository.

--- a/site/mex_invenio/config/settings.py
+++ b/site/mex_invenio/config/settings.py
@@ -239,15 +239,6 @@ S3_DOWNLOAD_FOLDER = "s3_downloads"
 
 COMMUNITIES_GROUPS_ENABLED = False
 
-# Script log config
-# --------------
-
-IMPORT_LOG_FILE = "logs/import_data.log"
-IMPORT_LOG_FORMAT = "%(asctime)s - %(levelname)s - (line: %(lineno)d) - %(message)s"
-
-S3_LOG_FILE = "logs/s3_manager.log"
-S3_LOG_FORMAT = IMPORT_LOG_FORMAT
-
 # The value for the Datacite creator property in imported records
 RECORD_METADATA_CREATOR = {
     "person_or_org": {

--- a/site/mex_invenio/scripts/import_data.py
+++ b/site/mex_invenio/scripts/import_data.py
@@ -29,17 +29,11 @@ from invenio_rdm_records.fixtures.tasks import get_authenticated_identity
 from invenio_rdm_records.proxies import current_rdm_records_service
 from multiprocessing import Pool, cpu_count
 
-from mex_invenio.config import IMPORT_LOG_FILE, IMPORT_LOG_FORMAT
 from mex_invenio.scripts.utils import compare_dicts, clean_dict, mex_to_invenio_schema
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-file_handler = logging.FileHandler(IMPORT_LOG_FILE)
-file_handler.setLevel(logging.INFO)
-formatter = logging.Formatter(IMPORT_LOG_FORMAT)
-file_handler.setFormatter(formatter)
-logger.addHandler(file_handler)
 
 
 def process_record(

--- a/site/mex_invenio/scripts/s3_manager.py
+++ b/site/mex_invenio/scripts/s3_manager.py
@@ -39,16 +39,9 @@ from mex_invenio.scripts.import_data import import_data
 from mex_invenio.scripts.utils import compare_files
 from datetime import datetime, timezone
 
-from mex_invenio.config import S3_LOG_FILE, S3_LOG_FORMAT
-
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-file_handler = logging.FileHandler(S3_LOG_FILE)
-file_handler.setLevel(logging.INFO)
-formatter = logging.Formatter(S3_LOG_FORMAT)
-file_handler.setFormatter(formatter)
-logger.addHandler(file_handler)
 
 envvar_prefix = "MEX_IMPORT_"
 


### PR DESCRIPTION
Despite the image not changing, we were getting permission denied when trying to write log files within `logs` dir in the pods. I've taken out the file handler entirely - the logs in stdout is sufficient for kubernetes, and if you want to log to file locally you can use output redirection `>` if needed.