### PR TITLE
Revert list sorting

### DIFF
--- a/site/mex_invenio/scripts/utils.py
+++ b/site/mex_invenio/scripts/utils.py
@@ -105,16 +105,12 @@ def normalize_record_data(value):
             for item in value
             if item is not None and item != []
         ]
-        # Sort list items for consistent comparison, handling mixed types
-        try:
-            return sorted(normalized_items, key=lambda x: (type(x).__name__, str(x)))
-        except TypeError:
-            # If items can't be sorted (e.g., complex nested structures), keep original order
-            return normalized_items
+
+        return normalized_items
     elif isinstance(value, dict):
         return {
             k: normalize_record_data(v)
-            for k, v in sorted(value.items())
+            for k, v in value.items()
             if v is not None and v != []
         }
     return value

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from mex_invenio.scripts.utils import get_title
+from mex_invenio.scripts.utils import get_title, normalize_record_data
 
 
 def test_get_title_with_valid_data(app):
@@ -23,3 +23,92 @@ def test_ignore_two_char_title(app):
 
     mex_data = {"name": [{"language": "en", "value": "ab"}], "title": "bab"}
     assert get_title(mex_data) == "bab"
+
+
+def test_normalize_record_data_string():
+    assert normalize_record_data("  hello world  ") == "hello world"
+    assert normalize_record_data("hello&nbsp;world") == "hello\xa0world"
+    assert normalize_record_data("hello&amp;world") == "hello&world"
+    assert normalize_record_data("test\u200bstring") == "teststring"
+    assert normalize_record_data("") == ""
+
+
+def test_normalize_record_data_numbers():
+    assert normalize_record_data(123) == "123"
+    assert normalize_record_data(123.45) == "123.45"
+    assert normalize_record_data(0) == "0"
+
+
+def test_normalize_record_data_list_order_preservation():
+    input_list = ["third", "first", "second"]
+    result = normalize_record_data(input_list)
+    assert result == ["third", "first", "second"]
+    assert result[0] == "third"
+    assert result[1] == "first"
+    assert result[2] == "second"
+
+
+def test_normalize_record_data_nested_list_order_preservation():
+    input_list = [
+        {"name": "charlie", "value": 3},
+        {"name": "alice", "value": 1},
+        {"name": "bob", "value": 2},
+    ]
+    result = normalize_record_data(input_list)
+    expected = [
+        {"name": "charlie", "value": "3"},
+        {"name": "alice", "value": "1"},
+        {"name": "bob", "value": "2"},
+    ]
+    assert result == expected
+    assert result[0]["name"] == "charlie"
+    assert result[1]["name"] == "alice"
+    assert result[2]["name"] == "bob"
+
+
+def test_normalize_record_data_list_with_none_and_empty():
+    input_list = ["first", None, "second", [], "third"]
+    result = normalize_record_data(input_list)
+    assert result == ["first", "second", "third"]
+
+
+def test_normalize_record_data_dict():
+    input_dict = {
+        "name": "  John Doe  ",
+        "age": 30,
+        "items": ["item1", "item2"],
+        "empty_list": [],
+        "null_value": None,
+    }
+    expected = {"name": "John Doe", "age": "30", "items": ["item1", "item2"]}
+    result = normalize_record_data(input_dict)
+    assert result == expected
+
+
+def test_normalize_record_data_complex_nested_structure():
+    input_data = {
+        "authors": [
+            {"name": "  Author 1  ", "id": 123},
+            {"name": "Author 2", "id": 456},
+        ],
+        "tags": ["python", "testing", "normalization"],
+        "metadata": {"title": "&quot;Complex Test&quot;", "year": 2024},
+    }
+    expected = {
+        "authors": [
+            {"name": "Author 1", "id": "123"},
+            {"name": "Author 2", "id": "456"},
+        ],
+        "tags": ["python", "testing", "normalization"],
+        "metadata": {"title": '"Complex Test"', "year": "2024"},
+    }
+    result = normalize_record_data(input_data)
+    assert result == expected
+    assert result["authors"][0]["name"] == "Author 1"
+    assert result["authors"][1]["name"] == "Author 2"
+
+
+def test_normalize_record_data_html_entities():
+    assert normalize_record_data("&lt;script&gt;") == "<script>"
+    assert normalize_record_data("M&uuml;ller") == "Müller"
+    assert normalize_record_data("caf&eacute;") == "café"


### PR DESCRIPTION
This removes any sorting of listed elements before comparison, meaning order matters and constitutes a change.