### PR TITLE
Feature/disable indexing during import

### DIFF
--- a/site/mex_invenio/scripts/import_data.py
+++ b/site/mex_invenio/scripts/import_data.py
@@ -37,28 +37,13 @@ from mex_invenio.scripts.utils import (
     mex_to_invenio_schema,
     normalize_record_data,
     cleanup_files,
+    setup_file_logging,
 )
 
 from mex_invenio.scripts.no_op_indexer import disable_indexing, re_enable_indexing
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-
-
-def _setup_file_logging(log_dir):
-    """Add a timestamped file handler to the logger."""
-    os.makedirs(log_dir, exist_ok=True)
-    date_str = time.strftime("%Y%m%d")
-    handler = logging.FileHandler(os.path.join(log_dir, f"import-{date_str}.log"))
-    handler.setLevel(logging.INFO)
-    handler.setFormatter(
-        logging.Formatter(
-            "%(asctime)s.%(msecs)03d - %(name)s - %(levelname)s - %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-    )
-    logger.addHandler(handler)
-    return handler
 
 
 def bulk_search_existing_records(mex_ids: list[str]) -> dict[str, dict]:
@@ -255,7 +240,8 @@ def import_data(
 
     with current_app.app_context():
         log_dir = os.path.join(current_app.config.get("S3_DOWNLOAD_FOLDER", "s3_downloads"), 'logs')
-        file_handler = _setup_file_logging(log_dir)
+        file_handler = setup_file_logging(log_dir)
+        logger.addHandler(file_handler)
         user_datastore = current_app.extensions["security"].datastore
         owner = user_datastore.find_user(email=email)
         logger.info(f"Importing {import_file}")
@@ -378,7 +364,7 @@ def import_data(
 
     logger.removeHandler(file_handler)
     file_handler.close()
-    cleanup_files(log_dir)
+    cleanup_files(log_dir, "import")
 
     return True
 

--- a/site/mex_invenio/scripts/import_data.py
+++ b/site/mex_invenio/scripts/import_data.py
@@ -199,7 +199,7 @@ def update_report(report: dict, batch_results: list[dict]):
         if result["action"] == "create":
             report["created"].append({"id": result["id"], "uuid": result["uuid"]})
         elif result["action"] == "update":
-            report["updated"].append({"id": result["id"], "uuid": result["uuid"]})
+            report["updated"].append({"id": result["id"], "uuid": result["uuid"], "parent": result["parent"]})
         elif result["action"] == "skip":
             report["skipped"].append(result["id"])
         elif result["action"] == "related":
@@ -302,20 +302,14 @@ def import_data(
         finally:
             re_enable_indexing(logger)
 
-        # Re-index related records while still in app context to keep
-        # SQLAlchemy instances bound to the active session
-        if report["related"]:
-            logger.info(f"Indexing {len(report['related'])} related records.")
-            current_rdm_records_service.indexer.bulk_index(r for r in report["related"])
-
-        # Re-indexing created and updated records in case there are any
-        # bi-directional relationships
-
+        # Index created and updated records first so that when related
+        # records are re-indexed, their display_data dumper can find the
+        # latest versions in the search index.
         if report["updated"]:
             parent_uuids = [r["parent"] for r in report["updated"]]
             updated_all_versions = db.session.query(RDMRecord.model_cls.id).filter(RDMRecord.model_cls.parent_id.in_(parent_uuids)).all()
             current_rdm_records_service.indexer.bulk_index(
-                u for u in updated_all_versions
+                u[0] for u in updated_all_versions
             )
 
         if report["created"]:
@@ -323,9 +317,16 @@ def import_data(
                 r["uuid"] for r in report["created"]
             )
 
-        # Process the bulk queue synchronously to ensure all records
-        # are indexed before the function returns
+        # Flush the queue so created/updated records are searchable
+        # before re-indexing related records that depend on them.
         current_rdm_records_service.indexer.process_bulk_queue()
+
+        # Re-index related records so their display_data reflects
+        # the newly created/updated records above.
+        if report["related"]:
+            logger.info(f"Indexing {len(report['related'])} related records.")
+            current_rdm_records_service.indexer.bulk_index(r for r in report["related"])
+            current_rdm_records_service.indexer.process_bulk_queue()
 
     # End the timer after processing is done
     end_time = time.time()

--- a/site/mex_invenio/scripts/import_data.py
+++ b/site/mex_invenio/scripts/import_data.py
@@ -39,6 +39,8 @@ from mex_invenio.scripts.utils import (
     cleanup_files,
 )
 
+from mex_invenio.scripts.no_op_indexer import disable_indexing, re_enable_indexing
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
@@ -59,7 +61,7 @@ def _setup_file_logging(log_dir):
     return handler
 
 
-def bulk_search_existing_records(mex_ids: list[str], identity) -> dict[str, dict]:
+def bulk_search_existing_records(mex_ids: list[str]) -> dict[str, dict]:
     """Search for multiple MEx IDs."""
     if not mex_ids:
         return {}
@@ -142,9 +144,6 @@ def process_record_batch(
                     }
                 )
 
-                for related_id in get_related_mex_ids(mex_data):
-                    results.append({"action": "related", "id": related_id})
-
             else:
                 # Update an existing record
                 record_pid = existing_record["id"]
@@ -169,13 +168,18 @@ def process_record_batch(
                             "action": "update",
                             "id": new_record.id,
                             "uuid": new_record._record.id,
+                            "parent": new_record._record.parent.id,
                         }
                     )
 
-                    for related_id in get_related_mex_ids(mex_data):
-                        results.append({"action": "related", "id": related_id})
                 else:
+                    # This shouldn't happen as the import files have been diffed
                     results.append({"action": "skip", "id": record_pid})
+                    continue
+
+                # Collect all related record UUIDs of created/updated records
+                for related_id in get_related_mex_ids(mex_data):
+                    results.append({"action": "related", "id": related_id})
 
         except json.JSONDecodeError:
             logger.error(f"Error decoding JSON: {json_data}")
@@ -198,7 +202,7 @@ def process_batch(batch_records: list[dict], identity) -> list[dict]:
     mex_ids = [record["identifier"] for record in batch_records]
 
     # Bulk search for existing records
-    existing_records = bulk_search_existing_records(mex_ids, identity)
+    existing_records = bulk_search_existing_records(mex_ids)
 
     # Process the batch
     return process_record_batch(batch_records, existing_records, identity)
@@ -277,35 +281,40 @@ def import_data(
     with current_app.app_context():
         identity = get_authenticated_identity(owner.id)
 
-        with open(import_file) as f:
-            batch_records = []
+        try:
+            disable_indexing(logger)
 
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
+            with open(import_file) as f:
+                batch_records = []
 
-                try:
-                    json_data = json.loads(line)
-                    batch_records.append(json_data)
-                    num_lines += 1
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
 
-                    logger.info(f"Processing line: {num_lines}")
+                    try:
+                        json_data = json.loads(line)
+                        batch_records.append(json_data)
+                        num_lines += 1
 
-                    # Process batch when it reaches batch_size
-                    if len(batch_records) >= batch_size:
-                        batch_results = process_batch(batch_records, identity)
-                        update_report(report, batch_results)
-                        batch_records = []
+                        logger.info(f"Processing line: {num_lines}")
 
-                except json.JSONDecodeError:
-                    logger.error(f"Error decoding JSON line: {line}")
-                    report["error"] += 1
+                        # Process batch when it reaches batch_size
+                        if len(batch_records) >= batch_size:
+                            batch_results = process_batch(batch_records, identity)
+                            update_report(report, batch_results)
+                            batch_records = []
 
-            # Process remaining records
-            if batch_records:
-                batch_results = process_batch(batch_records, identity)
-                update_report(report, batch_results)
+                    except json.JSONDecodeError:
+                        logger.error(f"Error decoding JSON line: {line}")
+                        report["error"] += 1
+
+                # Process remaining records
+                if batch_records:
+                    batch_results = process_batch(batch_records, identity)
+                    update_report(report, batch_results)
+        finally:
+            re_enable_indexing(logger)
 
         # Re-index related records while still in app context to keep
         # SQLAlchemy instances bound to the active session
@@ -313,9 +322,14 @@ def import_data(
             logger.info(f"Indexing {len(report['related'])} related records.")
             current_rdm_records_service.indexer.bulk_index(r for r in report["related"])
 
+        # Re-indexing created and updated records in case there are any
+        # bi-directional relationships
+
         if report["updated"]:
+            parent_uuids = [r["parent"] for r in report["updated"]]
+            updated_all_versions = db.session.query(RDMRecord.model_cls.id).filter(RDMRecord.model_cls.parent_id.in_(parent_uuids)).all()
             current_rdm_records_service.indexer.bulk_index(
-                r["uuid"] for r in report["updated"]
+                u for u in updated_all_versions
             )
 
         if report["created"]:

--- a/site/mex_invenio/scripts/initial_import.py
+++ b/site/mex_invenio/scripts/initial_import.py
@@ -30,37 +30,12 @@ import click
 from flask import current_app
 from invenio_rdm_records.fixtures.tasks import get_authenticated_identity
 from invenio_rdm_records.proxies import current_rdm_records_service
-from invenio_records_resources.services.uow import RecordCommitOp, RecordDeleteOp
 
 from mex_invenio.scripts.utils import (
     mex_to_invenio_schema,
 )
 
-
-# No-op indexer class to disable indexing during import
-class NoOpIndexer:
-    """A no-operation indexer that does nothing."""
-
-    def index(self, *args, **kwargs):
-        pass
-
-    def delete(self, *args, **kwargs):
-        pass
-
-    def delete_by_id(self, *args, **kwargs):
-        pass
-
-    def exists(self, *args, **kwargs):
-        return False
-
-    def bulk_index(self, *args, **kwargs):
-        pass
-
-    def bulk_delete(self, *args, **kwargs):
-        pass
-
-    def refresh(self, *args, **kwargs):
-        pass
+from mex_invenio.scripts.no_op_indexer import disable_indexing, re_enable_indexing
 
 
 # Configure logging
@@ -133,25 +108,9 @@ def initial_import(
             logger.error(message)
             return False
 
-    # Store original on_commit methods
-    original_record_commit_op = RecordCommitOp.on_commit
-    original_record_delete_op = RecordDeleteOp.on_commit
-
-    # Disable on_commit methods for performance
-    RecordCommitOp.on_commit = lambda self, uow: None
-    RecordDeleteOp.on_commit = lambda self, uow: None
-
-    # Temporarily disable indexing for performance
-    # IMPORTANT: indexer is a property that creates new instances, so we need to
-    # monkey-patch the property getter itself, not just set an attribute
-    # current_rdm_records_service is a LocalProxy, so we need to get the actual class
-    service_class = current_rdm_records_service.__class__
-    original_indexer_property = service_class.indexer
-    noop_indexer = NoOpIndexer()
-    service_class.indexer = property(lambda self: noop_indexer)
-    logger.info(
-        "Disabled indexing and commit operations during import for better performance"
-    )
+    # Disabling indexing to speed up import indexing has to be
+    # done manually after import has run
+    disable_indexing(logger)
 
     with current_app.app_context():
         user_datastore = current_app.extensions["security"].datastore
@@ -213,14 +172,7 @@ def initial_import(
                     batch_results = process_record_batch(batch_records, identity)
                     report.extend(batch_results)
         finally:
-            # Restore original indexer property
-            service_class.indexer = original_indexer_property
-
-            # Restore original on_commit methods
-            RecordCommitOp.on_commit = original_record_commit_op
-            RecordDeleteOp.on_commit = original_record_delete_op
-
-            logger.info("Restored indexing and commit operations")
+            re_enable_indexing(logger)
 
     # End the timer after processing is done
     end_time = time.time()

--- a/site/mex_invenio/scripts/no_op_indexer.py
+++ b/site/mex_invenio/scripts/no_op_indexer.py
@@ -1,0 +1,68 @@
+from invenio_records_resources.services.uow import RecordCommitOp, RecordDeleteOp
+from invenio_rdm_records.proxies import current_rdm_records_service
+
+
+# No-op indexer class to disable indexing during import
+class NoOpIndexer:
+    """A no-operation indexer that does nothing."""
+
+    def index(self, *args, **kwargs):
+        pass
+
+    def delete(self, *args, **kwargs):
+        pass
+
+    def delete_by_id(self, *args, **kwargs):
+        pass
+
+    def exists(self, *args, **kwargs):
+        return False
+
+    def bulk_index(self, *args, **kwargs):
+        pass
+
+    def bulk_delete(self, *args, **kwargs):
+        pass
+
+    def refresh(self, *args, **kwargs):
+        pass
+
+original_record_commit_op = None
+original_record_delete_op = None
+original_indexer_property = None
+
+def disable_indexing(logger):
+    global original_record_commit_op, original_record_delete_op, original_indexer_property
+
+    # Store original on_commit methods
+    original_record_commit_op = RecordCommitOp.on_commit
+    original_record_delete_op = RecordDeleteOp.on_commit
+
+    # Disable on_commit methods for performance
+    RecordCommitOp.on_commit = lambda self, uow: None
+    RecordDeleteOp.on_commit = lambda self, uow: None
+
+    # Temporarily disable indexing for performance
+    # IMPORTANT: indexer is a property that creates new instances, so we need to
+    # monkey-patch the property getter itself, not just set an attribute
+    # current_rdm_records_service is a LocalProxy, so we need to get the actual class
+    service_class = current_rdm_records_service.__class__
+    original_indexer_property = service_class.indexer
+    noop_indexer = NoOpIndexer()
+    service_class.indexer = property(lambda self: noop_indexer)
+    logger.info(
+        "Disabled indexing and commit operations during import for better performance"
+    )
+
+def re_enable_indexing(logger):
+    global original_record_commit_op, original_record_delete_op, original_indexer_property
+
+    service_class = current_rdm_records_service.__class__
+    # Restore original indexer property
+    service_class.indexer = original_indexer_property
+
+    # Restore original on_commit methods
+    RecordCommitOp.on_commit = original_record_commit_op
+    RecordDeleteOp.on_commit = original_record_delete_op
+
+    logger.info("Restored indexing and commit operations")

--- a/site/mex_invenio/scripts/s3_manager.py
+++ b/site/mex_invenio/scripts/s3_manager.py
@@ -8,7 +8,8 @@ pipenv run invenio shell site/mex_invenio/scripts/s3_manager.py
 
 ### Parameters
 The script takes the following parameters:
-**initial** Whether to import the data after downloading it from S3.
+**initial** Whether to do an initial import of the data after downloading it from S3 or
+            a standard one.
 
 ### Requirements
 Before running the script, there is a number of environment variables you can set:
@@ -38,11 +39,10 @@ from flask import current_app
 
 from mex_invenio.scripts.import_data import import_data
 from mex_invenio.scripts.initial_import import initial_import
-from mex_invenio.scripts.utils import compare_files, diff_files
+from mex_invenio.scripts.utils import compare_files, diff_files, setup_file_logging, cleanup_files
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 envvar_prefix = "MEX_IMPORT_"
 
@@ -128,6 +128,7 @@ def get_final_import_file(existing_file, new_file, payload_folder):
     """Handles file retention based on check flag."""
     if existing_file and compare_files(existing_file, new_file):
         logger.info("No new content found. File is exactly the same as before.")
+        logger.info(f"{new_file} deleted")
         return None  # New file is identical, so discard it
 
     # Generate a timestamped filename to avoid overwriting
@@ -169,8 +170,11 @@ def manage_s3_files(initial: bool = False):
         return
 
     # Get the download folder from config
-    s3_download_folder = current_app.config.get("S3_DOWNLOAD_FOLDER")
-    os.makedirs(s3_download_folder, exist_ok=True)
+    s3_download_folder = current_app.config.get("S3_DOWNLOAD_FOLDER", "s3_downloads")
+    log_dir = os.path.join(s3_download_folder, "logs")
+    os.makedirs(log_dir, exist_ok=True)
+    file_handler = setup_file_logging(log_dir, name="s3_manager")
+    logger.addHandler(file_handler)
     logger.info(f"Downloading file {latest_file_key} from bucket {s3_bucket}")
     logger.info(f"To download folder: {s3_download_folder}")
 
@@ -181,6 +185,8 @@ def manage_s3_files(initial: bool = False):
     new_file_path = download_file(
         s3_client, s3_bucket, latest_file_key, s3_download_folder
     )
+
+    logger.info(f"Download file {new_file_path} from bucket {s3_bucket}")
 
     if new_file_path:
         final_file_path = get_final_import_file(
@@ -201,6 +207,10 @@ def manage_s3_files(initial: bool = False):
                 sys.exit(1)
             else:
                 logger.info(f"Import successful. Data imported from {final_file_path}.")
+
+    logger.removeHandler(file_handler)
+    file_handler.close()
+    cleanup_files(log_dir, "s3_manager")
 
 
 if __name__ == "__main__":

--- a/site/mex_invenio/scripts/utils.py
+++ b/site/mex_invenio/scripts/utils.py
@@ -7,6 +7,7 @@ import importlib.metadata
 import json
 import logging
 import os
+import time
 from collections.abc import Callable
 from datetime import datetime
 
@@ -143,15 +144,24 @@ def compare_files(existing_file: str, new_file: str) -> bool:
     return False
 
 
-def cleanup_files(directory: str, keep: int = 20):
+def cleanup_files(directory: str, prefix: str = None, keep: int = 20):
     """Remove old files, keeping only the most recent ones."""
     try:
-        files = sorted(
-            [
+        if prefix:
+            files = [
                 os.path.join(directory, f)
                 for f in os.listdir(directory)
                 if os.path.isfile(os.path.join(directory, f))
-            ],
+                and f.startswith(prefix)
+            ]
+        else:
+            files = [
+                os.path.join(directory, f)
+                for f in os.listdir(directory)
+                if os.path.isfile(os.path.join(directory, f))
+            ]
+
+        files = sorted(files,
             key=os.path.getmtime,
             reverse=True,
         )
@@ -354,3 +364,17 @@ def get_related_mex_ids(record: dict) -> list:
     except Exception as e:
         logger.info(f"Error searching for related MEX IDs for {record_id}: {e}")
         return []
+
+def setup_file_logging(log_dir, name="import"):
+    """Add a timestamped file handler to the given logger."""
+    os.makedirs(log_dir, exist_ok=True)
+    date_str = time.strftime("%Y%m%d")
+    handler = logging.FileHandler(os.path.join(log_dir, f"{name}-{date_str}.log"))
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s.%(msecs)03d - %(name)s - %(levelname)s - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+    )
+    return handler

--- a/tests/test_s3_manager.py
+++ b/tests/test_s3_manager.py
@@ -60,7 +60,7 @@ def test_identical_files(
     assert result.exit_code == 0
     assert os.path.exists(existing_file_path)
     assert not os.path.exists(downloaded_file_path)
-    assert len(os.listdir(download_path)) == 1
+    assert len([f for f in os.listdir(download_path) if os.path.isfile(os.path.join(download_path, f))]) == 1
 
 
 @freeze_time("2023-01-01")


### PR DESCRIPTION
Reuses strategy to disable indexing between inital import and regular import.

During regular import all versions of an updated record are indexed.

Logging is shared between the import job and s3 manager.