### PR TITLE
override not working baseline

### DIFF
--- a/assets/less/site/globals/site.overrides
+++ b/assets/less/site/globals/site.overrides
@@ -173,7 +173,13 @@ code {
             display: grid;
             grid-template-columns: 30% 1fr;
             gap: 1rem;
-            align-items: baseline;
+            //align-items: baseline; // only works in newer Firefox
+            // workaround for older Firefox
+            align-items: flex-start;
+
+            button.ui.button.link-like:first-child {
+                padding-top: .25rem;
+            }
 
             .card-prop-label {
                 font-weight: 600;


### PR DESCRIPTION
`align-items: baseline` doesn't work correctly in the older Firefox v140. This is a workaround