### PR TITLE
adds indexing and facet for contributing units

### DIFF
--- a/site/mex_invenio/assets/semantic-ui/js/mex_invenio/search/bibliographic-resources.js
+++ b/site/mex_invenio/assets/semantic-ui/js/mex_invenio/search/bibliographic-resources.js
@@ -37,6 +37,7 @@ edges.instances.bibliographicResources.init = function () {
             mex.journalFacet(),
             mex.keywordFacet(),
             mex.publicationYearFacet(),
+            mex.contributingUnitFacet(),
 
             // Stuff above the results
             mex.resultCount(),

--- a/site/mex_invenio/assets/semantic-ui/js/mex_invenio/search/edges.common.js
+++ b/site/mex_invenio/assets/semantic-ui/js/mex_invenio/search/edges.common.js
@@ -47,6 +47,9 @@ mex.constants.BELONGS_TO_ID_KW = "custom_fields.mex:belongsTo.keyword"
 
 mex.constants.FUNDER_DE_KW = "index_data.deFunderOrCommissioners.keyword"
 mex.constants.FUNDER_EN_KW = "index_data.enFunderOrCommissioners.keyword"
+mex.constants.CONTRIBUTING_UNIT_DE_KW = "index_data.deContributingUnit.keyword"
+mex.constants.CONTRIBUTING_UNIT_EN_KW = "index_data.enContributingUnit.keyword"
+
 // FIXME: labels are multi-lingual, so which KW you use depends on the language, but this currently
 // isn't indexed to be used this way, so this will sort by whatever the first value is
 mex.constants.LABEL = "custom_fields.mex:label.value"
@@ -815,6 +818,19 @@ mex.publicationYearFacet = function () {
         interval: "year",
         useCheckboxes: true,
         showSelected: false,
+    });
+};
+
+mex.contributingUnitFacet = function () {
+    let field = mex.constants.CONTRIBUTING_UNIT_DE_KW;
+    if (mex.state.lang === "en") {
+        field = mex.constants.CONTRIBUTING_UNIT_EN_KW;
+    }
+    return mex.refiningAndFacet({
+        id: "contributing_unit",
+        field: field,
+        title: i18n.t("Contributing Unit"),
+        category: "left",
     });
 };
 

--- a/site/mex_invenio/assets/semantic-ui/js/mex_invenio/search/edges.common.js
+++ b/site/mex_invenio/assets/semantic-ui/js/mex_invenio/search/edges.common.js
@@ -829,7 +829,7 @@ mex.contributingUnitFacet = function () {
     return mex.refiningAndFacet({
         id: "contributing_unit",
         field: field,
-        title: i18n.t("Contributing Unit"),
+        title: i18n.t("contributingUnit.singular"),
         category: "left",
     });
 };

--- a/site/mex_invenio/assets/semantic-ui/js/mex_invenio/search/edges.common.js
+++ b/site/mex_invenio/assets/semantic-ui/js/mex_invenio/search/edges.common.js
@@ -47,8 +47,8 @@ mex.constants.BELONGS_TO_ID_KW = "custom_fields.mex:belongsTo.keyword"
 
 mex.constants.FUNDER_DE_KW = "index_data.deFunderOrCommissioners.keyword"
 mex.constants.FUNDER_EN_KW = "index_data.enFunderOrCommissioners.keyword"
-mex.constants.CONTRIBUTING_UNIT_DE_KW = "index_data.deContributingUnit.keyword"
-mex.constants.CONTRIBUTING_UNIT_EN_KW = "index_data.enContributingUnit.keyword"
+mex.constants.CONTRIBUTING_UNIT_DE_KW = "index_data.deContributingUnits.keyword"
+mex.constants.CONTRIBUTING_UNIT_EN_KW = "index_data.enContributingUnits.keyword"
 
 // FIXME: labels are multi-lingual, so which KW you use depends on the language, but this currently
 // isn't indexed to be used this way, so this will sort by whatever the first value is

--- a/site/mex_invenio/records/mappings/os-v2/mexrecords/records/record-v8.0.0.json
+++ b/site/mex_invenio/records/mappings/os-v2/mexrecords/records/record-v8.0.0.json
@@ -883,6 +883,15 @@
                         },
                         "type": "text"
                     },
+					"deContributingUnits": {
+                        "fields": {
+                            "keyword": {
+                                "ignore_above": 256,
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "text"
+                    },
                     "deUsedInResource": {
                         "fields": {
                             "keyword": {
@@ -917,6 +926,15 @@
                         "type": "object"
                     },
                     "enFunderOrCommissioners": {
+                        "fields": {
+                            "keyword": {
+                                "ignore_above": 256,
+                                "type": "keyword"
+                            }
+                        },
+                        "type": "text"
+                    },
+					"enContributingUnits": {
                         "fields": {
                             "keyword": {
                                 "ignore_above": 256,
@@ -2474,7 +2492,9 @@
             "index_data.enVariableGroups.value",
             "index_data.externalAssociates",
             "index_data.externalPartners",
-            "index_data.involvedPersons"
+            "index_data.involvedPersons",
+			"index_data.enContributingUnits",
+			"index_data.deContributingUnits"
         ]
     }
 }

--- a/site/mex_invenio/services/schema.py
+++ b/site/mex_invenio/services/schema.py
@@ -22,6 +22,8 @@ class IndexDataSchema(Schema):
     involvedPersons = fields.List(SanitizedUnicode(), dump_only=True)
     enUsedInResource = fields.List(SanitizedUnicode(), dump_only=True)
     deUsedInResource = fields.List(SanitizedUnicode(), dump_only=True)
+    enContributingUnits = fields.List(SanitizedUnicode(), dump_only=True)
+    deContributingUnits = fields.List(SanitizedUnicode(), dump_only=True)
 
 
 class MexRDMRecordSchema(RDMRecordSchema):

--- a/site/mex_invenio/services/search.py
+++ b/site/mex_invenio/services/search.py
@@ -91,6 +91,8 @@ FREE_TEXT_SEARCH_FIELDS = [
     "index_data.externalAssociates",
     "index_data.externalPartners",
     "index_data.involvedPersons",
+    "index_data.enContributingUnits",
+    "index_data.deContributingUnits"
 ]
 
 
@@ -137,6 +139,7 @@ class MexDumper(SearchDumper):
         self._involved_persons(record, dump_data, log)
         self._used_in(record, dump_data, log)
         self._resource_variables_groups(record, dump_data, log)
+        self._contributing_unit(record, dump_data, log)
 
         # log.append("**************************************")
         # log.append("Display data:")
@@ -174,7 +177,8 @@ class MexDumper(SearchDumper):
             record.json, "mex:alternativeName"
         )
         short_names = self._get_custom_field_list(record.json, "mex:shortName")
-        return official_names + alternative_names + short_names
+        general_name = self._get_custom_field_list(record.json, "mex:name")
+        return official_names + alternative_names + short_names + general_name
 
     def _get_all_possible_names(self, record):
         person = self._get_person_names(record)
@@ -463,6 +467,42 @@ class MexDumper(SearchDumper):
 
         if len(used_in_de) > 0:
             dump_data["index_data"]["deUsedInResource"] = used_in_de
+
+    def _contributing_unit(self, record, dump_data, log):
+        unit_ids = self._get_custom_field_list(record, "mex:contributingUnit")
+
+        if len(unit_ids) == 0:
+            return
+
+        log.append("Contributing Unit IDs:" + str(unit_ids))
+
+        results = self._records_by_mex_identifiers(record, unit_ids, log)
+        log.append("Contributing Unit results:" + str(len(results)))
+
+        units = []
+        for unit in results:
+            official_names = self._get_custom_field_list(
+                unit.json, "mex:name"
+            )
+            lang_names = self._split_by_language(official_names)
+            units.append(lang_names)
+
+        units_en = [fc["en"] for fc in units]
+        units_de = [fc["de"] for fc in units]
+
+        log.append("Contributing Units EN:" + str(units_en))
+        log.append("Contributing Units DE:" + str(units_de))
+
+        if len(units_en) == 0:
+            units_en = units_de
+        if len(units_de) == 0:
+            units_de = units_en
+
+        if len(units_de) > 0:
+            dump_data["index_data"]["deContributingUnits"] = units_de
+
+        if len(units_en) > 0:
+            dump_data["index_data"]["enContributingUnits"] = units_en
 
     def _records_by_mex_identifiers(self, source, mex_ids, log):
         results = []


### PR DESCRIPTION
### PR Context

Adds indexing rules and facet for contributing units on publications

https://github.com/robert-koch-institut/mex-invenio/issues/191

### Added

* Additional indexing rule to MexDumper
* Additional facet to bibliographic-resources.js

### Changes
* Additional facet on bibliographic resources search

### Deployment Considerations

This PR changes the index mapping and the indexed data so it MUST include a complete rebuild of the index including from the updated mappings.
