### PR TITLE
Feature/issue 235 model update UI settings for model v5.0

### DIFF
--- a/site/mex_invenio/config/settings.py
+++ b/site/mex_invenio/config/settings.py
@@ -511,6 +511,13 @@ UI_SETTINGS = {
                         "properties": [
                             {"field": "mex:relatedResource"},
                         ],
+                    },
+                    {
+                        "type": "component",
+                        "title": _("Source"),
+                        "properties": [
+                            {"field": "mex:source"},
+                        ],
                     }
                 ],
             },

--- a/site/mex_invenio/config/settings.py
+++ b/site/mex_invenio/config/settings.py
@@ -371,6 +371,7 @@ UI_SETTINGS = {
                 "properties": [
                     # overwritten in the template
                     {"field": "mex:theme"},
+                    {"field": "mex:healthCategory"}
                     {"field": "mex:keyword"},
                 ],
             },
@@ -390,6 +391,14 @@ UI_SETTINGS = {
                         "field": "mex:sizeOfDataBasis",
                         "label": _("sizeOfDataBasis.singular"),
                     },
+                    {
+                        "field": "mex:numberOfRecords",
+                        "label": _("numberOfRecords.singular"),
+                    },
+                    {
+                        "field": "mex:numberOfUniqueIndividuals",
+                        "label": _("numberOfUniqueIndividuals.singular"),
+                    }
                 ],
             },
             "legal": {

--- a/site/mex_invenio/config/settings.py
+++ b/site/mex_invenio/config/settings.py
@@ -533,6 +533,8 @@ UI_SETTINGS = {
                 "icon": "distribution.svg",
                 "properties": [
                     {"field": "mex:distribution"},
+                    {"field": "mex:analytics"},
+                    {"field": "mex:sample"}
                 ],
             },
             "variables": {

--- a/site/mex_invenio/config/settings.py
+++ b/site/mex_invenio/config/settings.py
@@ -381,6 +381,8 @@ UI_SETTINGS = {
                 "template": "coverage.html",
                 "properties": [
                     {"field": "mex:temporal", "label": _("temporal.singular")},
+                    {"field": "mex:start", "label": _("start.singular")},
+                    {"field": "mex:end", "label": _("end.singular")},
                     {"field": "mex:spatial", "label": _("spatial.singular")},
                     {"field": "fn", "label": _("Typical age")},
                     {

--- a/site/mex_invenio/config/settings.py
+++ b/site/mex_invenio/config/settings.py
@@ -370,8 +370,8 @@ UI_SETTINGS = {
                 "properties": [
                     # overwritten in the template
                     {"field": "mex:theme"},
-                    {"field": "mex:healthCategory"}
-                    {"field": "mex:keyword"},
+                    {"field": "mex:healthCategory"},
+                    {"field": "mex:keyword"}
                 ],
             },
             "coverage": {
@@ -379,11 +379,25 @@ UI_SETTINGS = {
                 "icon": "coverage.svg",
                 "template": "coverage.html",
                 "properties": [
-                    {"field": "mex:temporal", "label": _("temporal.singular")},
-                    {"field": "mex:start", "label": _("start.singular")},
-                    {"field": "mex:end", "label": _("end.singular")},
-                    {"field": "mex:spatial", "label": _("spatial.singular")},
-                    {"field": "fn", "label": _("Typical age")},
+                    {
+                        "field": "mex:temporal",
+                        "label": _("temporal.singular")},
+                    {
+                        "field": "mex:start",
+                        "label": _("start.singular")
+                    },
+                    {
+                        "field": "mex:end",
+                        "label": _("end.singular")
+                    },
+                    {
+                        "field": "mex:spatial",
+                        "label": _("spatial.singular")
+                    },
+                    {
+                        "field": "fn",
+                        "label": _("Typical age")
+                    },
                     {
                         "field": "mex:populationCoverage",
                         "label": _("populationCoverage.singular"),
@@ -479,7 +493,10 @@ UI_SETTINGS = {
                 "template": "methodology.html",
                 "properties": [
                     # overwritten in the template
-                    {"field": "mex:method", "label": _("method.singular")},
+                    {
+                        "field": "mex:method",
+                        "label": _("method.singular")
+                    },
                     {
                         "field": "mex:methodDescription",
                         "label": _("methodDescription.singular"),

--- a/site/mex_invenio/config/settings.py
+++ b/site/mex_invenio/config/settings.py
@@ -410,11 +410,18 @@ UI_SETTINGS = {
                         "field": "mex:hasLegalBasis",
                         "label": _("hasLegalBasis.singular"),
                     },
-                    {"field": "mex:hasPurpose", "label": _("hasPurpose.singular")},
+                    {
+                        "field": "mex:hasPurpose",
+                        "label": _("hasPurpose.singular")
+                    },
                     {
                         "field": "mex:hasPersonalData",
                         "label": _("hasPersonalData.singular"),
                     },
+                    {
+                        "field": "mex:source",
+                        "label": _("source.singular")
+                    }
                 ],
             },
             "processing": {
@@ -525,13 +532,6 @@ UI_SETTINGS = {
                         "title": _("Related Resource"),
                         "properties": [
                             {"field": "mex:relatedResource"},
-                        ],
-                    },
-                    {
-                        "type": "component",
-                        "title": _("Source"),
-                        "properties": [
-                            {"field": "mex:source"},
                         ],
                     }
                 ],

--- a/site/mex_invenio/config/settings.py
+++ b/site/mex_invenio/config/settings.py
@@ -654,6 +654,12 @@ UI_SETTINGS = {
                         ],
                     },
                     {
+                        "title": _("Related Activity"),
+                        "properties": [
+                            {"field": "mex:relatedActivity"},
+                        ],
+                    },
+                    {
                         "title": _("Related data sources & datasets"),
                         "properties": [
                             {

--- a/site/mex_invenio/config/settings.py
+++ b/site/mex_invenio/config/settings.py
@@ -343,6 +343,7 @@ UI_SETTINGS = {
             },
             "LOINC": {"field": "mex:loincId", "prefixes": ["https://loinc.org/"]},
             "ICD10": {"field": "mex:icd10code"},
+            "HAS_CODE_VALUES": {"field": "mex:hasCodeValues"}
             "TITLE": {"field": "mex:title"},
         },
         "main": {

--- a/site/mex_invenio/config/settings.py
+++ b/site/mex_invenio/config/settings.py
@@ -503,6 +503,13 @@ UI_SETTINGS = {
                             {"field": "mex:isPartOf", "is_backwards_linked": True},
                         ],
                     },
+                    {
+                        "type": "component",
+                        "title": _("Related Resource"),
+                        "properties": [
+                            {"field": "mex:relatedResource"},
+                        ],
+                    }
                 ],
             },
         },

--- a/site/mex_invenio/config/settings.py
+++ b/site/mex_invenio/config/settings.py
@@ -343,7 +343,6 @@ UI_SETTINGS = {
             },
             "LOINC": {"field": "mex:loincId", "prefixes": ["https://loinc.org/"]},
             "ICD10": {"field": "mex:icd10code"},
-            "HAS_CODE_VALUES": {"field": "mex:hasCodeValues"}
             "TITLE": {"field": "mex:title"},
         },
         "main": {
@@ -444,11 +443,19 @@ UI_SETTINGS = {
                 "title": _("Standards & Quality"),
                 "icon": "quality.svg",
                 "properties": [
-                    {"field": "mex:conformsTo", "label": _("conformsTo.singular")},
+                    {
+                        "field": "mex:conformsTo",
+                        "label": _("conformsTo.singular")
+                    },
                     {
                         "field": "mex:qualityInformation",
                         "label": _("qualityInformation.singular"),
                     },
+                    {
+                        "field": "mex:hasCodeValues",
+                        "label": _("hasCodeValues.singular")
+                    },
+
                 ],
             },
             "methodology": {

--- a/site/mex_invenio/config/settings.py
+++ b/site/mex_invenio/config/settings.py
@@ -455,6 +455,14 @@ UI_SETTINGS = {
                         "field": "mex:hasCodeValues",
                         "label": _("hasCodeValues.singular")
                     },
+                    {
+                        "field": "mex:analytics",
+                        "label": _("analytics.singular")
+                    },
+                    {
+                        "field": "mex:sample",
+                        "label": _("sample.singular")
+                    },
 
                 ],
             },
@@ -564,9 +572,7 @@ UI_SETTINGS = {
                 "title": _("Files"),
                 "icon": "distribution.svg",
                 "properties": [
-                    {"field": "mex:distribution"},
-                    {"field": "mex:analytics"},
-                    {"field": "mex:sample"}
+                    {"field": "mex:distribution"}
                 ],
             },
             "variables": {


### PR DESCRIPTION
### PR Context
Changed UI_SETTINGS according to mex-model v5.0, where some new optional fields were added. See also [mex-model release 5.0.1](https://github.com/robert-koch-institut/mex-model/releases/tag/5.0.1) and CHANGELOG.md for detailed information.

### Changes

Changed UI_SETTINGS in settings.py and added the following fields to "resource":

- analytics 
- end 
- hasCodeValues 
- healthCategory 
- numberOfRecords 
- numberOfUniqueIndividuals 
- relatedResource 
- sample 
- source 
- start 

... and "activity":

- relatedActivity
