### PR TITLE
Handle multiple concurrent model version dumps

### DIFF
--- a/site/mex_invenio/scripts/diff_manager.py
+++ b/site/mex_invenio/scripts/diff_manager.py
@@ -135,8 +135,19 @@ def generate_diff(model_version: str) -> str | None:
     processed_path = os.path.join(s3_download_folder, "processed")
     diff_path = os.path.join(s3_download_folder, "diffs")
 
-    oldest_download_path = get_subdir_by_order(downloaded_path, False)
-    most_recent_processed_path = get_subdir_by_order(processed_path)
+    # The pending download for this model version was just placed here by the
+    # caller, so it must be scoped to model_version rather than picked from
+    # across all versions' pending downloads.
+    oldest_download_path = get_subdir_by_order(
+        os.path.join(downloaded_path, model_version), False
+    )
+    # Prefer the most recent processed dump for this model version; fall back to
+    # the globally most recent processed dump (of any version) so that the first
+    # dump of a newly-introduced model version diffs against the last known good
+    # state during a version upgrade.
+    most_recent_processed_path = get_subdir_by_order(
+        os.path.join(processed_path, model_version)
+    ) or get_subdir_by_order(processed_path)
 
     if not oldest_download_path:
         logger.warning(f"No pending download found in {downloaded_path}.")

--- a/site/mex_invenio/scripts/import_data.py
+++ b/site/mex_invenio/scripts/import_data.py
@@ -16,7 +16,6 @@ To run the script, go to the repository root directory and use the following com
 """
 
 import copy
-import importlib.metadata
 import json
 import logging
 import os.path
@@ -26,7 +25,6 @@ import traceback
 from datetime import datetime, timezone
 
 import click
-import packaging.version
 from dictdiffer import diff
 from flask import current_app
 from invenio_db import db
@@ -40,6 +38,7 @@ from mex_invenio.scripts.no_op_indexer import disable_indexing, re_enable_indexi
 from mex_invenio.scripts.utils import (
     _read_state,
     _write_state,
+    get_installed_model_version,
     get_related_mex_ids,
     mex_to_invenio_schema,
     normalize_record_data,
@@ -381,8 +380,7 @@ def import_data(
                 )
                 return False
 
-    v = packaging.version.Version(importlib.metadata.version("mex-model"))
-    installed_model_version = f"{v.major}.{v.minor}"
+    installed_model_version = get_installed_model_version()
 
     if model_version != installed_model_version:
         # No interest in attempting to import incompatible data

--- a/site/mex_invenio/scripts/s3_manager.py
+++ b/site/mex_invenio/scripts/s3_manager.py
@@ -173,101 +173,103 @@ def manage_s3_files():
     if len(metadata_files) == 0:
         logger.info("No metadata files found in the bucket.")
         return
-    if len(metadata_files) > 1:
-        logger.info("Multiple metadata files found in the bucket.")
-        return
 
-    metadata_file = metadata_files[0]
+    for metadata_file in metadata_files:
+        # Create tmp draft downloaded location for dump
+        dump_folder = f"draft-{get_timestamp()}"
+        # e.g. s3_downloads/downloaded/tmp/draft-20260430104905
+        tmp_dump_path = os.path.join(download_path, "tmp", dump_folder)
+        os.makedirs(tmp_dump_path, exist_ok=True)
+        logger.info(f"Fetching metadata: {metadata_file['Key']}")
 
-    # Create tmp draft downloaded location for dump
-    dump_folder = f"draft-{get_timestamp()}"
-    # e.g. s3_downloads/downloaded/tmp/draft-20260430104905
-    tmp_dump_path = os.path.join(download_path, "tmp", dump_folder)
-    os.makedirs(tmp_dump_path, exist_ok=True)
-    logger.info(f"Fetching metadata: {metadata_file['Key']}")
+        # Download metadata file
+        new_metadata_file = os.path.join(tmp_dump_path, "metadata.json")
 
-    # Download metadata file
-    new_metadata_file = os.path.join(tmp_dump_path, "metadata.json")
+        try:
+            s3_client.download_file(s3_bucket, metadata_file["Key"], new_metadata_file)
+        except Exception as e:
+            logger.error(f"Failed to download file {new_metadata_file}: {e}")
+            shutil.rmtree(tmp_dump_path)
+            sys.exit(1)
 
-    try:
-        s3_client.download_file(s3_bucket, metadata_file["Key"], new_metadata_file)
-    except Exception as e:
-        logger.error(f"Failed to download file {new_metadata_file}: {e}")
-        shutil.rmtree(tmp_dump_path)
-        sys.exit(1)
+        try:
+            new_model_version, new_checksum, new_timestamp = read_json_file(
+                new_metadata_file
+            )
+        except Exception as e:
+            logger.error(f"Failed to read file {new_metadata_file}: {e}")
+            shutil.rmtree(tmp_dump_path)
+            continue
 
-    try:
-        new_model_version, new_checksum, new_timestamp = read_json_file(
-            new_metadata_file
-        )
-    except Exception as e:
-        logger.error(f"Failed to read file {new_metadata_file}: {e}")
-        shutil.rmtree(tmp_dump_path)
-        return
+        # Prefer the last processed dump for this model version; fall back to the
+        # globally most recent processed dump (of any version) so that the first
+        # dump of a newly-introduced model version diffs against the last known
+        # good state during a version upgrade.
+        last_processed_path = get_subdir_by_order(
+            os.path.join(processed_path, new_model_version)
+        ) or get_subdir_by_order(processed_path)
 
-    last_processed_path = get_subdir_by_order(processed_path)
+        if not last_processed_path:
+            logger.warning(
+                "No processed dump found; cannot determine if new data is available."
+            )
+            shutil.rmtree(tmp_dump_path)
+            continue
 
-    if not last_processed_path:
-        logger.warning(
-            "No processed dump found; cannot determine if new data is available."
-        )
-        shutil.rmtree(tmp_dump_path)
-        return
+        most_recent_metadata_file = os.path.join(last_processed_path, "metadata.json")
 
-    most_recent_metadata_file = os.path.join(last_processed_path, "metadata.json")
+        try:
+            _, last_checksum, last_timestamp = read_json_file(most_recent_metadata_file)
+        except Exception as e:
+            logger.error(f"Failed to read file {most_recent_metadata_file}: {e}")
+            shutil.rmtree(tmp_dump_path)
+            continue
 
-    try:
-        _, last_checksum, last_timestamp = read_json_file(most_recent_metadata_file)
-    except Exception as e:
-        logger.error(f"Failed to read file {most_recent_metadata_file}: {e}")
-        shutil.rmtree(tmp_dump_path)
-        return
+        # Only download if there is a new dump
+        if new_checksum == last_checksum and new_timestamp == last_timestamp:
+            logger.info(
+                "Dump is unchanged (checksum and timestamp match); nothing to import."
+            )
+            shutil.rmtree(tmp_dump_path)
+            continue
 
-    # Only download if there is a new dump
-    if new_checksum == last_checksum and new_timestamp == last_timestamp:
         logger.info(
-            "Dump is unchanged (checksum and timestamp match); nothing to import."
+            f"New dump detected (model={new_model_version}, timestamp={new_timestamp}, "
+            f"checksum={new_checksum}). Previous: timestamp={last_timestamp}, checksum={last_checksum}."
         )
-        shutil.rmtree(tmp_dump_path)
-        return
 
-    logger.info(
-        f"New dump detected (model={new_model_version}, timestamp={new_timestamp}, "
-        f"checksum={new_checksum}). Previous: timestamp={last_timestamp}, checksum={last_checksum}."
-    )
+        # Move from tmp path to download folder, download items file and remove draft- prefix
+        perm_download_path = os.path.join(download_path, new_model_version, dump_folder)
+        os.makedirs(os.path.dirname(perm_download_path), exist_ok=True)
+        shutil.move(tmp_dump_path, perm_download_path)
+        new_items_file = os.path.join(perm_download_path, "items.ndjson")
+        new_items_key = metadata_file["Key"].replace("metadata.json", "items.ndjson")
 
-    # Move from tmp path to download folder, download items file and remove draft- prefix
-    perm_download_path = os.path.join(download_path, new_model_version, dump_folder)
-    os.makedirs(os.path.dirname(perm_download_path), exist_ok=True)
-    shutil.move(tmp_dump_path, perm_download_path)
-    new_items_file = os.path.join(perm_download_path, "items.ndjson")
-    new_items_key = metadata_file["Key"].replace("metadata.json", "items.ndjson")
+        try:
+            s3_client.download_file(s3_bucket, new_items_key, new_items_file)
+        except Exception as e:
+            logger.error(f"Failed to download file {new_items_file}: {e}")
+            shutil.rmtree(perm_download_path)
+            sys.exit(1)
 
-    try:
-        s3_client.download_file(s3_bucket, new_items_key, new_items_file)
-    except Exception as e:
-        logger.error(f"Failed to download file {new_items_file}: {e}")
-        shutil.rmtree(perm_download_path)
-        sys.exit(1)
-
-    perm_download_folder_name = os.path.join(
-        download_path, new_model_version, dump_folder.removeprefix("draft-")
-    )
-    os.rename(perm_download_path, perm_download_folder_name)
-
-    # Compute diff file
-    diff_file = generate_diff(new_model_version)
-
-    if not diff_file:
-        logger.error(
-            f"Error creating diff file for model version: {new_model_version}."
+        perm_download_folder_name = os.path.join(
+            download_path, new_model_version, dump_folder.removeprefix("draft-")
         )
-        return
+        os.rename(perm_download_path, perm_download_folder_name)
 
-    successful_import = import_pending_diffs(s3_download_folder, user_email)
+        # Compute diff file
+        diff_file = generate_diff(new_model_version)
 
-    if not successful_import:
-        logger.error("Failed to import pending diffs.")
+        if not diff_file:
+            logger.error(
+                f"Error creating diff file for model version: {new_model_version}."
+            )
+            continue
+
+        successful_import = import_pending_diffs(s3_download_folder, user_email)
+
+        if not successful_import:
+            logger.error("Failed to import pending diffs.")
 
     logger.info("S3 sync complete.")
     return

--- a/site/mex_invenio/scripts/s3_manager.py
+++ b/site/mex_invenio/scripts/s3_manager.py
@@ -34,6 +34,7 @@ from flask import current_app
 from mex_invenio.scripts.diff_manager import generate_diff
 from mex_invenio.scripts.import_data import import_data
 from mex_invenio.scripts.utils import (
+    get_installed_model_version,
     get_subdir_by_order,
     get_timestamp,
     read_json_file,
@@ -124,6 +125,48 @@ def import_pending_diffs(s3_download_folder: str, user_email: str) -> bool:
     return True
 
 
+def get_model_metadata_files(contents):
+    """Return all bucket entries whose key matches 'publisher-<model_version>/metadata.json'."""
+    matches = []
+    for bucket_file in contents:
+        if re.search(r"publisher-\d+\.\d+/metadata\.json$", bucket_file["Key"]):
+            matches.append(bucket_file)
+    return matches
+
+
+def _download_items_file(
+    s3_client,
+    s3_bucket,
+    metadata_file,
+    download_path,
+    model_version,
+    dump_folder,
+    tmp_dump_path,
+):
+    """Move the downloaded metadata out of tmp and fetch the matching items.ndjson.
+
+    Returns True on success. On failure the permanent download dir is cleaned up.
+    """
+    perm_download_path = os.path.join(download_path, model_version, dump_folder)
+    os.makedirs(os.path.dirname(perm_download_path), exist_ok=True)
+    shutil.move(tmp_dump_path, perm_download_path)
+    new_items_file = os.path.join(perm_download_path, "items.ndjson")
+    new_items_key = metadata_file["Key"].replace("metadata.json", "items.ndjson")
+
+    try:
+        s3_client.download_file(s3_bucket, new_items_key, new_items_file)
+    except Exception as e:
+        logger.error(f"Failed to download file {new_items_file}: {e}")
+        shutil.rmtree(perm_download_path)
+        return False
+
+    perm_download_folder_name = os.path.join(
+        download_path, model_version, dump_folder.removeprefix("draft-")
+    )
+    os.rename(perm_download_path, perm_download_folder_name)
+    return True
+
+
 @click.command("manage_s3_files")
 def manage_s3_files():
     """Main function to download the latest file from S3, compare, and manage local storage."""
@@ -165,14 +208,15 @@ def manage_s3_files():
     download_path = os.path.join(s3_download_folder, "downloaded")
     processed_path = os.path.join(s3_download_folder, "processed")
 
-    # Get the metadata file
-    metadata_files = [
-        m for m in response["Contents"] if m["Key"].endswith("metadata.json")
-    ]
+    # Get every model-version dump available in the bucket
+    metadata_files = get_model_metadata_files(response["Contents"])
 
-    if len(metadata_files) == 0:
+    if not metadata_files:
         logger.info("No metadata files found in the bucket.")
         return
+
+    installed_model_version = get_installed_model_version()
+    had_download_errors = False
 
     for metadata_file in metadata_files:
         # Create tmp draft downloaded location for dump
@@ -190,7 +234,8 @@ def manage_s3_files():
         except Exception as e:
             logger.error(f"Failed to download file {new_metadata_file}: {e}")
             shutil.rmtree(tmp_dump_path)
-            sys.exit(1)
+            had_download_errors = True
+            continue
 
         try:
             new_model_version, new_checksum, new_timestamp = read_json_file(
@@ -200,6 +245,28 @@ def manage_s3_files():
             logger.error(f"Failed to read file {new_metadata_file}: {e}")
             shutil.rmtree(tmp_dump_path)
             continue
+
+        if new_model_version != installed_model_version:
+            # Not the version we process/diff -- just cache the dump so it's
+            # already available locally once this version becomes installed
+            # (upgrade transition).
+            logger.info(
+                f"Model version {new_model_version} does not match installed "
+                f"version {installed_model_version}; downloading only."
+            )
+            if not _download_items_file(
+                s3_client,
+                s3_bucket,
+                metadata_file,
+                download_path,
+                new_model_version,
+                dump_folder,
+                tmp_dump_path,
+            ):
+                had_download_errors = True
+            continue
+
+        # From here on: only for the dump matching the installed model version.
 
         # Prefer the last processed dump for this model version; fall back to the
         # globally most recent processed dump (of any version) so that the first
@@ -225,7 +292,7 @@ def manage_s3_files():
             shutil.rmtree(tmp_dump_path)
             continue
 
-        # Only download if there is a new dump
+        # Only download/diff/import if there is a new dump
         if new_checksum == last_checksum and new_timestamp == last_timestamp:
             logger.info(
                 "Dump is unchanged (checksum and timestamp match); nothing to import."
@@ -238,24 +305,17 @@ def manage_s3_files():
             f"checksum={new_checksum}). Previous: timestamp={last_timestamp}, checksum={last_checksum}."
         )
 
-        # Move from tmp path to download folder, download items file and remove draft- prefix
-        perm_download_path = os.path.join(download_path, new_model_version, dump_folder)
-        os.makedirs(os.path.dirname(perm_download_path), exist_ok=True)
-        shutil.move(tmp_dump_path, perm_download_path)
-        new_items_file = os.path.join(perm_download_path, "items.ndjson")
-        new_items_key = metadata_file["Key"].replace("metadata.json", "items.ndjson")
-
-        try:
-            s3_client.download_file(s3_bucket, new_items_key, new_items_file)
-        except Exception as e:
-            logger.error(f"Failed to download file {new_items_file}: {e}")
-            shutil.rmtree(perm_download_path)
-            sys.exit(1)
-
-        perm_download_folder_name = os.path.join(
-            download_path, new_model_version, dump_folder.removeprefix("draft-")
-        )
-        os.rename(perm_download_path, perm_download_folder_name)
+        if not _download_items_file(
+            s3_client,
+            s3_bucket,
+            metadata_file,
+            download_path,
+            new_model_version,
+            dump_folder,
+            tmp_dump_path,
+        ):
+            had_download_errors = True
+            continue
 
         # Compute diff file
         diff_file = generate_diff(new_model_version)
@@ -272,7 +332,9 @@ def manage_s3_files():
             logger.error("Failed to import pending diffs.")
 
     logger.info("S3 sync complete.")
-    return
+
+    if had_download_errors:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/site/mex_invenio/scripts/utils.py
+++ b/site/mex_invenio/scripts/utils.py
@@ -1,6 +1,7 @@
 """Utility functions for the MEx-Invenio data import and handling."""
 
 import html
+import importlib.metadata
 import json
 import logging
 import os
@@ -9,6 +10,7 @@ import time
 from collections.abc import Callable
 from datetime import datetime, timezone
 
+import packaging.version
 from invenio_db import db
 from invenio_rdm_records.records.api import RDMRecord
 from marshmallow_utils.html import sanitize_unicode
@@ -25,6 +27,12 @@ logger = logging.getLogger(__name__)
 
 def get_timestamp():
     return datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+
+
+def get_installed_model_version() -> str:
+    """Return the installed mex-model version as '<major>.<minor>'."""
+    v = packaging.version.Version(importlib.metadata.version("mex-model"))
+    return f"{v.major}.{v.minor}"
 
 
 def read_json_file(file_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import importlib.metadata
 import json
 import logging
 import os
@@ -6,7 +5,6 @@ import re
 from contextlib import suppress
 from unittest.mock import MagicMock, patch
 
-import packaging.version
 import pytest
 import sqlalchemy as sa
 
@@ -52,6 +50,7 @@ from mex_invenio.custom_fields.custom_fields import (
 from mex_invenio.records.api import MexRDMRecord
 from mex_invenio.scripts.import_data import _import_data
 from mex_invenio.scripts.initial_import import _initial_import
+from mex_invenio.scripts.utils import get_installed_model_version
 
 created_regex = (
     r"(?P<verb>\w+) (?P<count>\d) records. Ids: \[\'(?P<record_id>\w{5}-\w{5})\'\]"
@@ -156,8 +155,7 @@ def load_env():
 
 @pytest.fixture(scope="session")
 def model_version():
-    v = packaging.version.Version(importlib.metadata.version("mex-model"))
-    return f"{v.major}.{v.minor}"
+    return get_installed_model_version()
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_diff_manager.py
+++ b/tests/test_diff_manager.py
@@ -165,3 +165,95 @@ def test_generate_diff_success(
     assert "20240301000001" in result
     mock_compute.assert_called_once()
     mock_move.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# generate_diff — model-version scoping and upgrade-transition fallback
+# ---------------------------------------------------------------------------
+
+
+def test_generate_diff_oldest_download_scoped_to_model_version(app_ctx, app_config):
+    """The pending-download lookup is scoped to this model version only."""
+    seen_roots = []
+
+    def subdir(root, most_recent=True):  # noqa: FBT002
+        seen_roots.append((root, most_recent))
+
+    with patch(f"{_MODULE}.get_subdir_by_order", side_effect=subdir):
+        assert generate_diff("5.0") is None
+
+    base = str(app_config["S3_DOWNLOAD_FOLDER"])
+    # The pending-download lookup (always the first call) must be scoped to
+    # this model version; unrelated to whether a fallback happens afterwards
+    # for the processed-dump lookup.
+    assert seen_roots[0] == (os.path.join(base, "downloaded", "5.0"), False)
+
+
+@patch(f"{_MODULE}.get_timestamp", new=lambda: "20260201000001")
+@patch(f"{_MODULE}.shutil.move")
+@patch(
+    f"{_MODULE}.compute_diff",
+    return_value={"new_or_changed_count": 3, "processed_count": 3},
+)
+def test_generate_diff_falls_back_to_other_version_when_first_run(
+    mock_compute, mock_move, app_ctx, app_config
+):
+    """A brand-new model version diffs against the most recent processed dump of any version when it has no processed history of its own (upgrade transition, e.g. 4.10 -> 5.0)."""
+    base = str(app_config["S3_DOWNLOAD_FOLDER"])
+    dl_sub = os.path.join(base, "downloaded", "5.0", "20260201000000")
+    pr_sub_410 = os.path.join(base, "processed", "4.10", "20260101000000")
+    os.makedirs(dl_sub, exist_ok=True)
+    os.makedirs(pr_sub_410, exist_ok=True)
+
+    def subdir(root, most_recent=True):  # noqa: FBT002
+        if root == os.path.join(base, "downloaded", "5.0"):
+            return dl_sub
+        if root == os.path.join(base, "processed", "5.0"):
+            return None  # no processed history yet for the new version
+        if root == os.path.join(base, "processed"):
+            return pr_sub_410  # global fallback finds the old version's dump
+        return None
+
+    with patch(f"{_MODULE}.get_subdir_by_order", side_effect=subdir):
+        result = generate_diff("5.0")
+
+    assert result is not None
+    downloaded_file, processed_file, _diff_file = mock_compute.call_args[0]
+    assert downloaded_file == os.path.join(dl_sub, "items.ndjson")
+    assert processed_file == os.path.join(pr_sub_410, "items.ndjson")
+
+
+@patch(f"{_MODULE}.get_timestamp", new=lambda: "20260301000001")
+@patch(f"{_MODULE}.shutil.move")
+@patch(
+    f"{_MODULE}.compute_diff",
+    return_value={"new_or_changed_count": 1, "processed_count": 1},
+)
+def test_generate_diff_prefers_own_version_processed_over_other_versions(
+    mock_compute, mock_move, app_ctx, app_config
+):
+    """A model version's own processed history is used as the diff baseline, never another version's, even if that other version's dump sorts as more recent."""
+    base = str(app_config["S3_DOWNLOAD_FOLDER"])
+    dl_sub = os.path.join(base, "downloaded", "5.0", "20260301000000")
+    pr_sub_50 = os.path.join(base, "processed", "5.0", "20260201000000")
+    pr_sub_410 = os.path.join(base, "processed", "4.10", "20260225000000")
+    os.makedirs(dl_sub, exist_ok=True)
+    os.makedirs(pr_sub_50, exist_ok=True)
+    os.makedirs(pr_sub_410, exist_ok=True)
+
+    def subdir(root, most_recent=True):  # noqa: FBT002
+        if root == os.path.join(base, "downloaded", "5.0"):
+            return dl_sub
+        if root == os.path.join(base, "processed", "5.0"):
+            return pr_sub_50
+        if root == os.path.join(base, "processed"):
+            # Would be picked up if scoping were broken -- must not be used.
+            return pr_sub_410
+        return None
+
+    with patch(f"{_MODULE}.get_subdir_by_order", side_effect=subdir):
+        result = generate_diff("5.0")
+
+    assert result is not None
+    _downloaded_file, processed_file, _diff_file = mock_compute.call_args[0]
+    assert processed_file == os.path.join(pr_sub_50, "items.ndjson")

--- a/tests/test_s3_manager.py
+++ b/tests/test_s3_manager.py
@@ -355,3 +355,121 @@ def test_diff_failure_skips_import(
 
     assert result.exit_code == 0
     mock_import_pending.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# manage_s3_files — multiple model versions in the same bucket/run
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{_MODULE}.get_timestamp", new=lambda: "20260401000001")
+@patch(f"{_MODULE}.import_pending_diffs")
+@patch(f"{_MODULE}.generate_diff")
+@patch(f"{_MODULE}.read_json_file")
+@patch(f"{_MODULE}.get_subdir_by_order")
+def test_unchanged_version_does_not_block_other_versions_in_same_run(
+    mock_get_subdir,
+    mock_read_json,
+    mock_generate_diff,
+    mock_import_pending,
+    cli_runner,
+    app_config,
+    s3_client,
+):
+    """One model version being unchanged must not stop other versions in the same bucket listing from being downloaded and diffed in the same run."""
+    download_folder = str(app_config["S3_DOWNLOAD_FOLDER"])
+    processed_path = os.path.join(download_folder, "processed")
+    last_processed_410 = os.path.join(processed_path, "4.10", "20260101000000")
+
+    def fake_subdir(root, most_recent=True):  # noqa: FBT002
+        if root == os.path.join(processed_path, "4.10"):
+            return last_processed_410
+        if root == os.path.join(processed_path, "5.0"):
+            return None  # 5.0 has no processed history yet
+        if root == processed_path:
+            return last_processed_410  # global fallback for 5.0's first run
+        return None
+
+    mock_get_subdir.side_effect = fake_subdir
+    mock_read_json.side_effect = [
+        ("4.10", "same_checksum", "2026-01-01T00:00:00Z"),  # 4.10 new metadata
+        ("4.10", "same_checksum", "2026-01-01T00:00:00Z"),  # 4.10 last processed
+        ("5.0", "new_checksum", "2026-04-01T00:00:00Z"),  # 5.0 new metadata
+        ("4.10", "same_checksum", "2026-01-01T00:00:00Z"),  # fallback baseline
+    ]
+    mock_generate_diff.return_value = os.path.join(
+        download_folder, "diffs", "20260401000001", "diff.ndjson"
+    )
+    mock_import_pending.return_value = True
+
+    def fake_download(bucket, key, dest):
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        with open(dest, "w") as f:
+            f.write("{}")
+
+    s3_client.download_file.side_effect = fake_download
+    s3_client.list_objects_v2.return_value = {
+        "Contents": [
+            {"Key": "4.10/metadata.json", "LastModified": "2026-01-01"},
+            {"Key": "5.0/metadata.json", "LastModified": "2026-04-01"},
+        ]
+    }
+
+    result = cli_runner(manage_s3_files)
+
+    assert result.exit_code == 0
+    mock_generate_diff.assert_called_once_with("5.0")
+    mock_import_pending.assert_called_once()
+
+
+@patch(f"{_MODULE}.get_timestamp", new=lambda: "20260501000001")
+@patch(f"{_MODULE}.import_pending_diffs")
+@patch(f"{_MODULE}.generate_diff")
+@patch(f"{_MODULE}.read_json_file")
+@patch(f"{_MODULE}.get_subdir_by_order")
+def test_new_model_version_falls_back_to_other_version_baseline(
+    mock_get_subdir,
+    mock_read_json,
+    mock_generate_diff,
+    mock_import_pending,
+    cli_runner,
+    app_config,
+    s3_client,
+):
+    """The first dump of a new model version compares against the last processed dump of whatever version came before it, instead of being skipped as 'no processed dump found'."""
+    download_folder = str(app_config["S3_DOWNLOAD_FOLDER"])
+    processed_path = os.path.join(download_folder, "processed")
+    fallback_path = os.path.join(processed_path, "4.10", "20260101000000")
+
+    def fake_subdir(root, most_recent=True):  # noqa: FBT002
+        if root == os.path.join(processed_path, "5.0"):
+            return None  # no 5.0 history yet
+        if root == processed_path:
+            return fallback_path
+        return None
+
+    mock_get_subdir.side_effect = fake_subdir
+    mock_read_json.side_effect = [
+        ("5.0", "new_checksum", "2026-04-01T00:00:00Z"),
+        ("4.10", "old_checksum", "2026-01-01T00:00:00Z"),
+    ]
+    mock_generate_diff.return_value = os.path.join(
+        download_folder, "diffs", "20260501000001", "diff.ndjson"
+    )
+    mock_import_pending.return_value = True
+
+    def fake_download(bucket, key, dest):
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        with open(dest, "w") as f:
+            f.write("{}")
+
+    s3_client.download_file.side_effect = fake_download
+    s3_client.list_objects_v2.return_value = {
+        "Contents": [{"Key": "5.0/metadata.json", "LastModified": "2026-04-01"}]
+    }
+
+    result = cli_runner(manage_s3_files)
+
+    assert result.exit_code == 0
+    mock_generate_diff.assert_called_once_with("5.0")
+    mock_import_pending.assert_called_once()

--- a/tests/test_s3_manager.py
+++ b/tests/test_s3_manager.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from mex_invenio.scripts.s3_manager import (
+    get_model_metadata_files,
     get_s3_client_and_config,
     import_pending_diffs,
     manage_s3_files,
@@ -131,6 +132,31 @@ def test_import_pending_diffs_skips_corrupt_metadata(mock_import, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# get_model_metadata_files
+# ---------------------------------------------------------------------------
+
+
+def test_get_model_metadata_files_matches_publisher_prefix():
+    """Only 'publisher-<version>/metadata.json' keys are matched."""
+    contents = [
+        {"Key": "publisher-4.10/metadata.json"},
+        {"Key": "publisher-5.0/metadata.json"},
+        {"Key": "publisher-4.10/items.ndjson"},
+        {"Key": "publisher.ndjson"},
+        {"Key": "DatenkompassActivity.xlsx"},
+        {"Key": "some/other/metadata.json"},
+    ]
+    matched = [f["Key"] for f in get_model_metadata_files(contents)]
+    assert matched == ["publisher-4.10/metadata.json", "publisher-5.0/metadata.json"]
+
+
+def test_get_model_metadata_files_empty_when_no_match():
+    """Returns an empty list when nothing in the bucket matches."""
+    contents = [{"Key": "publisher.ndjson"}, {"Key": "DatenkompassActivity.xlsx"}]
+    assert get_model_metadata_files(contents) == []
+
+
+# ---------------------------------------------------------------------------
 # manage_s3_files
 # ---------------------------------------------------------------------------
 
@@ -150,11 +176,11 @@ def test_no_metadata_file(cli_runner, app_config, s3_client):
 
 
 def test_multiple_metadata_files(cli_runner, app_config, s3_client):
-    """Script exits cleanly when S3 bucket has multiple metadata.json files."""
+    """Script exits cleanly when S3 bucket has multiple matching metadata.json files."""
     s3_client.list_objects_v2.return_value = {
         "Contents": [
-            {"Key": "v1/metadata.json", "LastModified": "2024-01-01"},
-            {"Key": "v2/metadata.json", "LastModified": "2024-01-02"},
+            {"Key": "publisher-4.10/metadata.json", "LastModified": "2024-01-01"},
+            {"Key": "publisher-5.0/metadata.json", "LastModified": "2024-01-02"},
         ]
     }
     assert cli_runner(manage_s3_files).exit_code == 0
@@ -178,7 +204,9 @@ def test_s3_client_config_failure(cli_runner, app_config, base_app):
 def test_metadata_download_failure(cli_runner, app_config, s3_client):
     """Script exits with code 1 (retry) when the S3 metadata download fails."""
     s3_client.list_objects_v2.return_value = {
-        "Contents": [{"Key": "4.10/metadata.json", "LastModified": "2024-01-01"}]
+        "Contents": [
+            {"Key": "publisher-4.10/metadata.json", "LastModified": "2024-01-01"}
+        ]
     }
     s3_client.download_file.side_effect = Exception("network error")
     assert cli_runner(manage_s3_files).exit_code == 1
@@ -188,27 +216,35 @@ def test_metadata_download_failure(cli_runner, app_config, s3_client):
 def test_read_new_metadata_failure(mock_read, cli_runner, app_config, s3_client):
     """Script exits cleanly when reading the downloaded metadata.json fails."""
     s3_client.list_objects_v2.return_value = {
-        "Contents": [{"Key": "4.10/metadata.json", "LastModified": "2024-01-01"}]
+        "Contents": [
+            {"Key": "publisher-4.10/metadata.json", "LastModified": "2024-01-01"}
+        ]
     }
     assert cli_runner(manage_s3_files).exit_code == 0
 
 
+@patch(f"{_MODULE}.get_installed_model_version", return_value="4.10")
 @patch(f"{_MODULE}.get_subdir_by_order", return_value=None)
 @patch(
     f"{_MODULE}.read_json_file", return_value=("4.10", "abc", "2024-01-01T00:00:00Z")
 )
-def test_no_processed_dump(mock_read, mock_subdir, cli_runner, app_config, s3_client):
+def test_no_processed_dump(
+    mock_read, mock_subdir, mock_installed_version, cli_runner, app_config, s3_client
+):
     """Script exits cleanly when no processed dump exists to compare the checksum against."""
     s3_client.list_objects_v2.return_value = {
-        "Contents": [{"Key": "4.10/metadata.json", "LastModified": "2024-01-01"}]
+        "Contents": [
+            {"Key": "publisher-4.10/metadata.json", "LastModified": "2024-01-01"}
+        ]
     }
     assert cli_runner(manage_s3_files).exit_code == 0
 
 
+@patch(f"{_MODULE}.get_installed_model_version", return_value="4.10")
 @patch(f"{_MODULE}.read_json_file")
 @patch(f"{_MODULE}.get_subdir_by_order")
 def test_read_last_metadata_failure(
-    mock_subdir, mock_read, cli_runner, app_config, s3_client
+    mock_subdir, mock_read, mock_installed_version, cli_runner, app_config, s3_client
 ):
     """Script exits cleanly when reading the existing local metadata.json fails."""
     dl = os.path.join(str(app_config["S3_DOWNLOAD_FOLDER"]), "downloaded")
@@ -218,22 +254,32 @@ def test_read_last_metadata_failure(
         Exception("read error"),
     ]
     s3_client.list_objects_v2.return_value = {
-        "Contents": [{"Key": "4.10/metadata.json", "LastModified": "2024-01-05"}]
+        "Contents": [
+            {"Key": "publisher-4.10/metadata.json", "LastModified": "2024-01-05"}
+        ]
     }
     assert cli_runner(manage_s3_files).exit_code == 0
 
 
+@patch(f"{_MODULE}.get_installed_model_version", return_value="4.10")
 @patch(f"{_MODULE}.read_json_file")
 @patch(f"{_MODULE}.get_subdir_by_order")
 def test_identical_checksums_skips_download(
-    mock_get_subdir, mock_read_json, cli_runner, app_config, s3_client
+    mock_get_subdir,
+    mock_read_json,
+    mock_installed_version,
+    cli_runner,
+    app_config,
+    s3_client,
 ):
     """Script skips download when new metadata matches existing checksum and timestamp."""
     dl = os.path.join(str(app_config["S3_DOWNLOAD_FOLDER"]), "downloaded")
     mock_get_subdir.return_value = os.path.join(dl, "4.10", "20240101000000")
     mock_read_json.return_value = ("4.10", "abc123checksum", "2024-01-01T00:00:00Z")
     s3_client.list_objects_v2.return_value = {
-        "Contents": [{"Key": "4.10/metadata.json", "LastModified": "2024-01-01"}]
+        "Contents": [
+            {"Key": "publisher-4.10/metadata.json", "LastModified": "2024-01-01"}
+        ]
     }
 
     result = cli_runner(manage_s3_files)
@@ -243,10 +289,11 @@ def test_identical_checksums_skips_download(
 
 
 @patch(f"{_MODULE}.get_timestamp", new=lambda: "20240105000001")
+@patch(f"{_MODULE}.get_installed_model_version", return_value="4.10")
 @patch(f"{_MODULE}.read_json_file")
 @patch(f"{_MODULE}.get_subdir_by_order")
 def test_items_download_failure(
-    mock_subdir, mock_read, cli_runner, app_config, s3_client
+    mock_subdir, mock_read, mock_installed_version, cli_runner, app_config, s3_client
 ):
     """Script exits with code 1 (retry) when the S3 items file download fails."""
     dl = os.path.join(str(app_config["S3_DOWNLOAD_FOLDER"]), "downloaded")
@@ -256,7 +303,9 @@ def test_items_download_failure(
         ("4.10", "ck_old", "2024-01-01T00:00:00Z"),
     ]
     s3_client.list_objects_v2.return_value = {
-        "Contents": [{"Key": "4.10/metadata.json", "LastModified": "2024-01-05"}]
+        "Contents": [
+            {"Key": "publisher-4.10/metadata.json", "LastModified": "2024-01-05"}
+        ]
     }
     call_count = [0]
 
@@ -274,6 +323,7 @@ def test_items_download_failure(
 
 
 @patch(f"{_MODULE}.get_timestamp", new=lambda: "20240102000001")
+@patch(f"{_MODULE}.get_installed_model_version", return_value="4.10")
 @patch(f"{_MODULE}.import_pending_diffs")
 @patch(f"{_MODULE}.generate_diff")
 @patch(f"{_MODULE}.read_json_file")
@@ -283,6 +333,7 @@ def test_new_checksum_triggers_download_and_import(
     mock_read_json,
     mock_generate_diff,
     mock_import_pending,
+    mock_installed_version,
     cli_runner,
     app_config,
     s3_client,
@@ -307,7 +358,9 @@ def test_new_checksum_triggers_download_and_import(
 
     s3_client.download_file.side_effect = fake_download
     s3_client.list_objects_v2.return_value = {
-        "Contents": [{"Key": "4.10/metadata.json", "LastModified": "2024-01-02"}]
+        "Contents": [
+            {"Key": "publisher-4.10/metadata.json", "LastModified": "2024-01-02"}
+        ]
     }
 
     result = cli_runner(manage_s3_files)
@@ -318,6 +371,7 @@ def test_new_checksum_triggers_download_and_import(
 
 
 @patch(f"{_MODULE}.get_timestamp", new=lambda: "20240103000001")
+@patch(f"{_MODULE}.get_installed_model_version", return_value="4.10")
 @patch(f"{_MODULE}.import_pending_diffs")
 @patch(f"{_MODULE}.generate_diff")
 @patch(f"{_MODULE}.read_json_file")
@@ -327,6 +381,7 @@ def test_diff_failure_skips_import(
     mock_read_json,
     mock_generate_diff,
     mock_import_pending,
+    mock_installed_version,
     cli_runner,
     app_config,
     s3_client,
@@ -348,7 +403,9 @@ def test_diff_failure_skips_import(
 
     s3_client.download_file.side_effect = fake_download
     s3_client.list_objects_v2.return_value = {
-        "Contents": [{"Key": "4.10/metadata.json", "LastModified": "2024-01-02"}]
+        "Contents": [
+            {"Key": "publisher-4.10/metadata.json", "LastModified": "2024-01-02"}
+        ]
     }
 
     result = cli_runner(manage_s3_files)
@@ -363,6 +420,7 @@ def test_diff_failure_skips_import(
 
 
 @patch(f"{_MODULE}.get_timestamp", new=lambda: "20260401000001")
+@patch(f"{_MODULE}.get_installed_model_version", return_value="5.0")
 @patch(f"{_MODULE}.import_pending_diffs")
 @patch(f"{_MODULE}.generate_diff")
 @patch(f"{_MODULE}.read_json_file")
@@ -372,30 +430,40 @@ def test_unchanged_version_does_not_block_other_versions_in_same_run(
     mock_read_json,
     mock_generate_diff,
     mock_import_pending,
+    mock_installed_version,
     cli_runner,
     app_config,
     s3_client,
 ):
-    """One model version being unchanged must not stop other versions in the same bucket listing from being downloaded and diffed in the same run."""
+    """A non-installed-version dump (download-only) must not stop the installed version's dump from being reached and diffed in the same run."""
     download_folder = str(app_config["S3_DOWNLOAD_FOLDER"])
     processed_path = os.path.join(download_folder, "processed")
     last_processed_410 = os.path.join(processed_path, "4.10", "20260101000000")
 
     def fake_subdir(root, most_recent=True):  # noqa: FBT002
-        if root == os.path.join(processed_path, "4.10"):
-            return last_processed_410
         if root == os.path.join(processed_path, "5.0"):
-            return None  # 5.0 has no processed history yet
+            return None  # 5.0 (installed) has no processed history yet
         if root == processed_path:
             return last_processed_410  # global fallback for 5.0's first run
         return None
 
     mock_get_subdir.side_effect = fake_subdir
     mock_read_json.side_effect = [
-        ("4.10", "same_checksum", "2026-01-01T00:00:00Z"),  # 4.10 new metadata
-        ("4.10", "same_checksum", "2026-01-01T00:00:00Z"),  # 4.10 last processed
-        ("5.0", "new_checksum", "2026-04-01T00:00:00Z"),  # 5.0 new metadata
-        ("4.10", "same_checksum", "2026-01-01T00:00:00Z"),  # fallback baseline
+        (
+            "4.10",
+            "unused_checksum",
+            "2026-01-01T00:00:00Z",
+        ),  # 4.10 new metadata (not installed)
+        (
+            "5.0",
+            "new_checksum",
+            "2026-04-01T00:00:00Z",
+        ),  # 5.0 new metadata (installed version)
+        (
+            "4.10",
+            "old_checksum",
+            "2026-01-01T00:00:00Z",
+        ),  # fallback baseline (4.10's last processed)
     ]
     mock_generate_diff.return_value = os.path.join(
         download_folder, "diffs", "20260401000001", "diff.ndjson"
@@ -410,8 +478,8 @@ def test_unchanged_version_does_not_block_other_versions_in_same_run(
     s3_client.download_file.side_effect = fake_download
     s3_client.list_objects_v2.return_value = {
         "Contents": [
-            {"Key": "4.10/metadata.json", "LastModified": "2026-01-01"},
-            {"Key": "5.0/metadata.json", "LastModified": "2026-04-01"},
+            {"Key": "publisher-4.10/metadata.json", "LastModified": "2026-01-01"},
+            {"Key": "publisher-5.0/metadata.json", "LastModified": "2026-04-01"},
         ]
     }
 
@@ -423,6 +491,7 @@ def test_unchanged_version_does_not_block_other_versions_in_same_run(
 
 
 @patch(f"{_MODULE}.get_timestamp", new=lambda: "20260501000001")
+@patch(f"{_MODULE}.get_installed_model_version", return_value="5.0")
 @patch(f"{_MODULE}.import_pending_diffs")
 @patch(f"{_MODULE}.generate_diff")
 @patch(f"{_MODULE}.read_json_file")
@@ -432,6 +501,7 @@ def test_new_model_version_falls_back_to_other_version_baseline(
     mock_read_json,
     mock_generate_diff,
     mock_import_pending,
+    mock_installed_version,
     cli_runner,
     app_config,
     s3_client,
@@ -465,7 +535,9 @@ def test_new_model_version_falls_back_to_other_version_baseline(
 
     s3_client.download_file.side_effect = fake_download
     s3_client.list_objects_v2.return_value = {
-        "Contents": [{"Key": "5.0/metadata.json", "LastModified": "2026-04-01"}]
+        "Contents": [
+            {"Key": "publisher-5.0/metadata.json", "LastModified": "2026-04-01"}
+        ]
     }
 
     result = cli_runner(manage_s3_files)
@@ -473,3 +545,47 @@ def test_new_model_version_falls_back_to_other_version_baseline(
     assert result.exit_code == 0
     mock_generate_diff.assert_called_once_with("5.0")
     mock_import_pending.assert_called_once()
+
+
+@patch(f"{_MODULE}.get_timestamp", new=lambda: "20260601000001")
+@patch(f"{_MODULE}.get_installed_model_version", return_value="4.10")
+@patch(f"{_MODULE}.read_json_file", return_value=("5.0", "ck", "2026-06-01T00:00:00Z"))
+@patch(f"{_MODULE}.import_pending_diffs")
+@patch(f"{_MODULE}.generate_diff")
+def test_non_installed_version_downloads_but_never_diffs(
+    mock_generate_diff,
+    mock_import_pending,
+    mock_read_json,
+    mock_installed_version,
+    cli_runner,
+    app_config,
+    s3_client,
+):
+    """A dump whose model version doesn't match the installed one is downloaded (metadata + items) but never diffed or imported."""
+    download_folder = str(app_config["S3_DOWNLOAD_FOLDER"])
+    download_path = os.path.join(download_folder, "downloaded")
+
+    def fake_download(bucket, key, dest):
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        with open(dest, "w") as f:
+            f.write("{}")
+
+    s3_client.download_file.side_effect = fake_download
+    s3_client.list_objects_v2.return_value = {
+        "Contents": [
+            {"Key": "publisher-5.0/metadata.json", "LastModified": "2026-06-01"}
+        ]
+    }
+
+    result = cli_runner(manage_s3_files)
+
+    assert result.exit_code == 0
+    # Both metadata.json and items.ndjson were fetched...
+    assert s3_client.download_file.call_count == 2
+    # ...but the dump was never diffed or imported, since 5.0 != installed 4.10.
+    mock_generate_diff.assert_not_called()
+    mock_import_pending.assert_not_called()
+    # And it's cached on disk under its own version, ready for a future upgrade.
+    cached_dir = os.path.join(download_path, "5.0", "20260601000001")
+    assert os.path.exists(os.path.join(cached_dir, "metadata.json"))
+    assert os.path.exists(os.path.join(cached_dir, "items.ndjson"))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,10 @@
-from mex_invenio.scripts.utils import get_title, normalize_record_data
+from unittest.mock import patch
+
+from mex_invenio.scripts.utils import (
+    get_installed_model_version,
+    get_title,
+    normalize_record_data,
+)
 
 
 def test_get_title_with_valid_data(app):
@@ -112,3 +118,11 @@ def test_normalize_record_data_html_entities():
     assert normalize_record_data("&lt;script&gt;") == "<script>"
     assert normalize_record_data("M&uuml;ller") == "Müller"
     assert normalize_record_data("caf&eacute;") == "café"
+
+
+def test_get_installed_model_version_truncates_to_major_minor():
+    """Returns '<major>.<minor>', dropping any patch component."""
+    with patch(
+        "mex_invenio.scripts.utils.importlib.metadata.version", return_value="4.10.3"
+    ):
+        assert get_installed_model_version() == "4.10"


### PR DESCRIPTION
The S3 bucket currently contains two different dumps.